### PR TITLE
Remove versioning from schema

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -20,7 +20,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.0.6</version>
+    <version>1.1.0</version>
     <authors>
         <author>
             <name>Antony Penalver</name>

--- a/Config/schema.xml
+++ b/Config/schema.xml
@@ -12,10 +12,6 @@
         <behavior name="i18n">
             <parameter name="i18n_columns" value="title,description"/>
         </behavior>
-        <behavior name="versionable">
-            <parameter name="log_created_at" value="true"/>
-            <parameter name="log_created_by" value="true"/>
-        </behavior>
     </table>
 
     <table name="person" namespace="Team\Model">
@@ -27,10 +23,6 @@
         <behavior name="timestampable"/>
         <behavior name="i18n">
             <parameter name="i18n_columns" value="description"/>
-        </behavior>
-        <behavior name="versionable">
-            <parameter name="log_created_at" value="true"/>
-            <parameter name="log_created_by" value="true"/>
         </behavior>
     </table>
 
@@ -48,10 +40,6 @@
         </foreign-key>
 
         <behavior name="timestampable"/>
-        <behavior name="versionable">
-            <parameter name="log_created_at" value="true"/>
-            <parameter name="log_created_by" value="true"/>
-        </behavior>
     </table>
 
     <table name="person_image" namespace="Team\Model">
@@ -81,10 +69,6 @@
         <behavior name="i18n">
             <parameter name="i18n_columns" value="title, description, chapo, postscriptum" />
         </behavior>
-        <behavior name="versionable">
-            <parameter name="log_created_at" value="true"/>
-            <parameter name="log_created_by" value="true"/>
-        </behavior>
     </table>
 
     <table name="person_function" namespace="Team\Model">
@@ -95,10 +79,6 @@
         <behavior name="timestampable"/>
         <behavior name="i18n">
             <parameter name="i18n_columns" value="label"/>
-        </behavior>
-        <behavior name="versionable">
-            <parameter name="log_created_at" value="true"/>
-            <parameter name="log_created_by" value="true"/>
         </behavior>
     </table>
 
@@ -116,10 +96,6 @@
         </foreign-key>
 
         <behavior name="timestampable"/>
-        <behavior name="versionable">
-            <parameter name="log_created_at" value="true"/>
-            <parameter name="log_created_by" value="true"/>
-        </behavior>
     </table>
 
 </database>

--- a/Config/thelia.sql
+++ b/Config/thelia.sql
@@ -14,9 +14,6 @@ CREATE TABLE `team`
     `id` INTEGER NOT NULL AUTO_INCREMENT,
     `created_at` DATETIME,
     `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
@@ -33,9 +30,6 @@ CREATE TABLE `person`
     `last_name` VARCHAR(255),
     `created_at` DATETIME,
     `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
@@ -52,9 +46,6 @@ CREATE TABLE `person_team_link`
     `team_id` INTEGER NOT NULL,
     `created_at` DATETIME,
     `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
     PRIMARY KEY (`id`),
     INDEX `FI_person_team_link_person_id` (`person_id`),
     INDEX `FI_person_team_link_team_id` (`team_id`),
@@ -83,9 +74,6 @@ CREATE TABLE `person_image`
     `position` INTEGER,
     `created_at` DATETIME,
     `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
     PRIMARY KEY (`id`),
     INDEX `idx_person_image_person_id` (`person_id`),
     INDEX `idx_person_image_person_id_position` (`person_id`, `position`),
@@ -107,9 +95,6 @@ CREATE TABLE `person_function`
     `code` VARCHAR(255),
     `created_at` DATETIME,
     `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
@@ -126,9 +111,6 @@ CREATE TABLE `person_function_link`
     `function_id` INTEGER NOT NULL,
     `created_at` DATETIME,
     `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
     PRIMARY KEY (`id`),
     INDEX `FI_person_function_link_person_id` (`person_id`),
     INDEX `FI_person_function_link_function_id` (`function_id`),
@@ -215,158 +197,6 @@ CREATE TABLE `person_function_i18n`
     CONSTRAINT `person_function_i18n_FK_1`
         FOREIGN KEY (`id`)
         REFERENCES `person_function` (`id`)
-        ON DELETE CASCADE
-) ENGINE=InnoDB;
-
--- ---------------------------------------------------------------------
--- team_version
--- ---------------------------------------------------------------------
-
-DROP TABLE IF EXISTS `team_version`;
-
-CREATE TABLE `team_version`
-(
-    `id` INTEGER NOT NULL,
-    `created_at` DATETIME,
-    `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0 NOT NULL,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
-    `person_team_link_ids` TEXT,
-    `person_team_link_versions` TEXT,
-    PRIMARY KEY (`id`,`version`),
-    CONSTRAINT `team_version_FK_1`
-        FOREIGN KEY (`id`)
-        REFERENCES `team` (`id`)
-        ON DELETE CASCADE
-) ENGINE=InnoDB;
-
--- ---------------------------------------------------------------------
--- person_version
--- ---------------------------------------------------------------------
-
-DROP TABLE IF EXISTS `person_version`;
-
-CREATE TABLE `person_version`
-(
-    `id` INTEGER NOT NULL,
-    `first_name` VARCHAR(255),
-    `last_name` VARCHAR(255),
-    `created_at` DATETIME,
-    `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0 NOT NULL,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
-    `person_team_link_ids` TEXT,
-    `person_team_link_versions` TEXT,
-    `person_image_ids` TEXT,
-    `person_image_versions` TEXT,
-    `person_function_link_ids` TEXT,
-    `person_function_link_versions` TEXT,
-    PRIMARY KEY (`id`,`version`),
-    CONSTRAINT `person_version_FK_1`
-        FOREIGN KEY (`id`)
-        REFERENCES `person` (`id`)
-        ON DELETE CASCADE
-) ENGINE=InnoDB;
-
--- ---------------------------------------------------------------------
--- person_team_link_version
--- ---------------------------------------------------------------------
-
-DROP TABLE IF EXISTS `person_team_link_version`;
-
-CREATE TABLE `person_team_link_version`
-(
-    `id` INTEGER NOT NULL,
-    `person_id` INTEGER NOT NULL,
-    `team_id` INTEGER NOT NULL,
-    `created_at` DATETIME,
-    `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0 NOT NULL,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
-    `person_id_version` INTEGER DEFAULT 0,
-    `team_id_version` INTEGER DEFAULT 0,
-    PRIMARY KEY (`id`,`version`),
-    CONSTRAINT `person_team_link_version_FK_1`
-        FOREIGN KEY (`id`)
-        REFERENCES `person_team_link` (`id`)
-        ON DELETE CASCADE
-) ENGINE=InnoDB;
-
--- ---------------------------------------------------------------------
--- person_image_version
--- ---------------------------------------------------------------------
-
-DROP TABLE IF EXISTS `person_image_version`;
-
-CREATE TABLE `person_image_version`
-(
-    `id` INTEGER NOT NULL,
-    `file` VARCHAR(255),
-    `person_id` INTEGER NOT NULL,
-    `visible` TINYINT DEFAULT 1 NOT NULL,
-    `position` INTEGER,
-    `created_at` DATETIME,
-    `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0 NOT NULL,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
-    `person_id_version` INTEGER DEFAULT 0,
-    PRIMARY KEY (`id`,`version`),
-    CONSTRAINT `person_image_version_FK_1`
-        FOREIGN KEY (`id`)
-        REFERENCES `person_image` (`id`)
-        ON DELETE CASCADE
-) ENGINE=InnoDB;
-
--- ---------------------------------------------------------------------
--- person_function_version
--- ---------------------------------------------------------------------
-
-DROP TABLE IF EXISTS `person_function_version`;
-
-CREATE TABLE `person_function_version`
-(
-    `id` INTEGER NOT NULL,
-    `code` VARCHAR(255),
-    `created_at` DATETIME,
-    `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0 NOT NULL,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
-    `person_function_link_ids` TEXT,
-    `person_function_link_versions` TEXT,
-    PRIMARY KEY (`id`,`version`),
-    CONSTRAINT `person_function_version_FK_1`
-        FOREIGN KEY (`id`)
-        REFERENCES `person_function` (`id`)
-        ON DELETE CASCADE
-) ENGINE=InnoDB;
-
--- ---------------------------------------------------------------------
--- person_function_link_version
--- ---------------------------------------------------------------------
-
-DROP TABLE IF EXISTS `person_function_link_version`;
-
-CREATE TABLE `person_function_link_version`
-(
-    `id` INTEGER NOT NULL,
-    `person_id` INTEGER NOT NULL,
-    `function_id` INTEGER NOT NULL,
-    `created_at` DATETIME,
-    `updated_at` DATETIME,
-    `version` INTEGER DEFAULT 0 NOT NULL,
-    `version_created_at` DATETIME,
-    `version_created_by` VARCHAR(100),
-    `person_id_version` INTEGER DEFAULT 0,
-    `function_id_version` INTEGER DEFAULT 0,
-    PRIMARY KEY (`id`,`version`),
-    CONSTRAINT `person_function_link_version_FK_1`
-        FOREIGN KEY (`id`)
-        REFERENCES `person_function_link` (`id`)
         ON DELETE CASCADE
 ) ENGINE=InnoDB;
 

--- a/Model/Base/Person.php
+++ b/Model/Base/Person.php
@@ -20,23 +20,14 @@ use Propel\Runtime\Util\PropelDateTime;
 use Team\Model\Person as ChildPerson;
 use Team\Model\PersonFunctionLink as ChildPersonFunctionLink;
 use Team\Model\PersonFunctionLinkQuery as ChildPersonFunctionLinkQuery;
-use Team\Model\PersonFunctionLinkVersionQuery as ChildPersonFunctionLinkVersionQuery;
 use Team\Model\PersonI18n as ChildPersonI18n;
 use Team\Model\PersonI18nQuery as ChildPersonI18nQuery;
 use Team\Model\PersonImage as ChildPersonImage;
 use Team\Model\PersonImageQuery as ChildPersonImageQuery;
-use Team\Model\PersonImageVersionQuery as ChildPersonImageVersionQuery;
 use Team\Model\PersonQuery as ChildPersonQuery;
 use Team\Model\PersonTeamLink as ChildPersonTeamLink;
 use Team\Model\PersonTeamLinkQuery as ChildPersonTeamLinkQuery;
-use Team\Model\PersonTeamLinkVersionQuery as ChildPersonTeamLinkVersionQuery;
-use Team\Model\PersonVersion as ChildPersonVersion;
-use Team\Model\PersonVersionQuery as ChildPersonVersionQuery;
-use Team\Model\Map\PersonFunctionLinkVersionTableMap;
-use Team\Model\Map\PersonImageVersionTableMap;
 use Team\Model\Map\PersonTableMap;
-use Team\Model\Map\PersonTeamLinkVersionTableMap;
-use Team\Model\Map\PersonVersionTableMap;
 
 abstract class Person implements ActiveRecordInterface
 {
@@ -103,25 +94,6 @@ abstract class Person implements ActiveRecordInterface
     protected $updated_at;
 
     /**
-     * The value for the version field.
-     * Note: this column has a database default value of: 0
-     * @var        int
-     */
-    protected $version;
-
-    /**
-     * The value for the version_created_at field.
-     * @var        string
-     */
-    protected $version_created_at;
-
-    /**
-     * The value for the version_created_by field.
-     * @var        string
-     */
-    protected $version_created_by;
-
-    /**
      * @var        ObjectCollection|ChildPersonTeamLink[] Collection to store aggregation of ChildPersonTeamLink objects.
      */
     protected $collPersonTeamLinks;
@@ -146,12 +118,6 @@ abstract class Person implements ActiveRecordInterface
     protected $collPersonI18nsPartial;
 
     /**
-     * @var        ObjectCollection|ChildPersonVersion[] Collection to store aggregation of ChildPersonVersion objects.
-     */
-    protected $collPersonVersions;
-    protected $collPersonVersionsPartial;
-
-    /**
      * Flag to prevent endless save loop, if this object is referenced
      * by another object which falls in this transaction.
      *
@@ -172,14 +138,6 @@ abstract class Person implements ActiveRecordInterface
      * @var        array[ChildPersonI18n]
      */
     protected $currentTranslations;
-
-    // versionable behavior
-
-
-    /**
-     * @var bool
-     */
-    protected $enforceVersion = false;
 
     /**
      * An array of objects scheduled for deletion.
@@ -206,29 +164,10 @@ abstract class Person implements ActiveRecordInterface
     protected $personI18nsScheduledForDeletion = null;
 
     /**
-     * An array of objects scheduled for deletion.
-     * @var ObjectCollection
-     */
-    protected $personVersionsScheduledForDeletion = null;
-
-    /**
-     * Applies default values to this object.
-     * This method should be called from the object's constructor (or
-     * equivalent initialization method).
-     * @see __construct()
-     */
-    public function applyDefaultValues()
-    {
-        $this->version = 0;
-    }
-
-    /**
      * Initializes internal state of Team\Model\Base\Person object.
-     * @see applyDefaults()
      */
     public function __construct()
     {
-        $this->applyDefaultValues();
     }
 
     /**
@@ -556,48 +495,6 @@ abstract class Person implements ActiveRecordInterface
     }
 
     /**
-     * Get the [version] column value.
-     *
-     * @return   int
-     */
-    public function getVersion()
-    {
-
-        return $this->version;
-    }
-
-    /**
-     * Get the [optionally formatted] temporal [version_created_at] column value.
-     *
-     *
-     * @param      string $format The date/time format string (either date()-style or strftime()-style).
-     *                            If format is NULL, then the raw \DateTime object will be returned.
-     *
-     * @return mixed Formatted date/time value as string or \DateTime object (if format is NULL), NULL if column is NULL, and 0 if column value is 0000-00-00 00:00:00
-     *
-     * @throws PropelException - if unable to parse/validate the date/time value.
-     */
-    public function getVersionCreatedAt($format = NULL)
-    {
-        if ($format === null) {
-            return $this->version_created_at;
-        } else {
-            return $this->version_created_at instanceof \DateTime ? $this->version_created_at->format($format) : null;
-        }
-    }
-
-    /**
-     * Get the [version_created_by] column value.
-     *
-     * @return   string
-     */
-    public function getVersionCreatedBy()
-    {
-
-        return $this->version_created_by;
-    }
-
-    /**
      * Set the value of [id] column.
      *
      * @param      int $v new value
@@ -703,69 +600,6 @@ abstract class Person implements ActiveRecordInterface
     } // setUpdatedAt()
 
     /**
-     * Set the value of [version] column.
-     *
-     * @param      int $v new value
-     * @return   \Team\Model\Person The current object (for fluent API support)
-     */
-    public function setVersion($v)
-    {
-        if ($v !== null) {
-            $v = (int) $v;
-        }
-
-        if ($this->version !== $v) {
-            $this->version = $v;
-            $this->modifiedColumns[PersonTableMap::VERSION] = true;
-        }
-
-
-        return $this;
-    } // setVersion()
-
-    /**
-     * Sets the value of [version_created_at] column to a normalized version of the date/time value specified.
-     *
-     * @param      mixed $v string, integer (timestamp), or \DateTime value.
-     *               Empty strings are treated as NULL.
-     * @return   \Team\Model\Person The current object (for fluent API support)
-     */
-    public function setVersionCreatedAt($v)
-    {
-        $dt = PropelDateTime::newInstance($v, null, '\DateTime');
-        if ($this->version_created_at !== null || $dt !== null) {
-            if ($dt !== $this->version_created_at) {
-                $this->version_created_at = $dt;
-                $this->modifiedColumns[PersonTableMap::VERSION_CREATED_AT] = true;
-            }
-        } // if either are not null
-
-
-        return $this;
-    } // setVersionCreatedAt()
-
-    /**
-     * Set the value of [version_created_by] column.
-     *
-     * @param      string $v new value
-     * @return   \Team\Model\Person The current object (for fluent API support)
-     */
-    public function setVersionCreatedBy($v)
-    {
-        if ($v !== null) {
-            $v = (string) $v;
-        }
-
-        if ($this->version_created_by !== $v) {
-            $this->version_created_by = $v;
-            $this->modifiedColumns[PersonTableMap::VERSION_CREATED_BY] = true;
-        }
-
-
-        return $this;
-    } // setVersionCreatedBy()
-
-    /**
      * Indicates whether the columns in this object are only set to default values.
      *
      * This method can be used in conjunction with isModified() to indicate whether an object is both
@@ -775,10 +609,6 @@ abstract class Person implements ActiveRecordInterface
      */
     public function hasOnlyDefaultValues()
     {
-            if ($this->version !== 0) {
-                return false;
-            }
-
         // otherwise, everything was equal, so return TRUE
         return true;
     } // hasOnlyDefaultValues()
@@ -826,18 +656,6 @@ abstract class Person implements ActiveRecordInterface
                 $col = null;
             }
             $this->updated_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : PersonTableMap::translateFieldName('Version', TableMap::TYPE_PHPNAME, $indexType)];
-            $this->version = (null !== $col) ? (int) $col : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : PersonTableMap::translateFieldName('VersionCreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
-            if ($col === '0000-00-00 00:00:00') {
-                $col = null;
-            }
-            $this->version_created_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : PersonTableMap::translateFieldName('VersionCreatedBy', TableMap::TYPE_PHPNAME, $indexType)];
-            $this->version_created_by = (null !== $col) ? (string) $col : null;
             $this->resetModified();
 
             $this->setNew(false);
@@ -846,7 +664,7 @@ abstract class Person implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 8; // 8 = PersonTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 5; // 5 = PersonTableMap::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception $e) {
             throw new PropelException("Error populating \Team\Model\Person object", 0, $e);
@@ -914,8 +732,6 @@ abstract class Person implements ActiveRecordInterface
             $this->collPersonFunctionLinks = null;
 
             $this->collPersonI18ns = null;
-
-            $this->collPersonVersions = null;
 
         } // if (deep)
     }
@@ -985,14 +801,6 @@ abstract class Person implements ActiveRecordInterface
         $isInsert = $this->isNew();
         try {
             $ret = $this->preSave($con);
-            // versionable behavior
-            if ($this->isVersioningNecessary()) {
-                $this->setVersion($this->isNew() ? 1 : $this->getLastVersionNumber($con) + 1);
-                if (!$this->isColumnModified(PersonTableMap::VERSION_CREATED_AT)) {
-                    $this->setVersionCreatedAt(time());
-                }
-                $createVersion = true; // for postSave hook
-            }
             if ($isInsert) {
                 $ret = $ret && $this->preInsert($con);
                 // timestampable behavior
@@ -1017,10 +825,6 @@ abstract class Person implements ActiveRecordInterface
                     $this->postUpdate($con);
                 }
                 $this->postSave($con);
-                // versionable behavior
-                if (isset($createVersion)) {
-                    $this->addVersion($con);
-                }
                 PersonTableMap::addInstanceToPool($this);
             } else {
                 $affectedRows = 0;
@@ -1130,23 +934,6 @@ abstract class Person implements ActiveRecordInterface
                 }
             }
 
-            if ($this->personVersionsScheduledForDeletion !== null) {
-                if (!$this->personVersionsScheduledForDeletion->isEmpty()) {
-                    \Team\Model\PersonVersionQuery::create()
-                        ->filterByPrimaryKeys($this->personVersionsScheduledForDeletion->getPrimaryKeys(false))
-                        ->delete($con);
-                    $this->personVersionsScheduledForDeletion = null;
-                }
-            }
-
-                if ($this->collPersonVersions !== null) {
-            foreach ($this->collPersonVersions as $referrerFK) {
-                    if (!$referrerFK->isDeleted() && ($referrerFK->isNew() || $referrerFK->isModified())) {
-                        $affectedRows += $referrerFK->save($con);
-                    }
-                }
-            }
-
             $this->alreadyInSave = false;
 
         }
@@ -1188,15 +975,6 @@ abstract class Person implements ActiveRecordInterface
         if ($this->isColumnModified(PersonTableMap::UPDATED_AT)) {
             $modifiedColumns[':p' . $index++]  = 'UPDATED_AT';
         }
-        if ($this->isColumnModified(PersonTableMap::VERSION)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION';
-        }
-        if ($this->isColumnModified(PersonTableMap::VERSION_CREATED_AT)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION_CREATED_AT';
-        }
-        if ($this->isColumnModified(PersonTableMap::VERSION_CREATED_BY)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION_CREATED_BY';
-        }
 
         $sql = sprintf(
             'INSERT INTO person (%s) VALUES (%s)',
@@ -1222,15 +1000,6 @@ abstract class Person implements ActiveRecordInterface
                         break;
                     case 'UPDATED_AT':
                         $stmt->bindValue($identifier, $this->updated_at ? $this->updated_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
-                        break;
-                    case 'VERSION':
-                        $stmt->bindValue($identifier, $this->version, PDO::PARAM_INT);
-                        break;
-                    case 'VERSION_CREATED_AT':
-                        $stmt->bindValue($identifier, $this->version_created_at ? $this->version_created_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
-                        break;
-                    case 'VERSION_CREATED_BY':
-                        $stmt->bindValue($identifier, $this->version_created_by, PDO::PARAM_STR);
                         break;
                 }
             }
@@ -1309,15 +1078,6 @@ abstract class Person implements ActiveRecordInterface
             case 4:
                 return $this->getUpdatedAt();
                 break;
-            case 5:
-                return $this->getVersion();
-                break;
-            case 6:
-                return $this->getVersionCreatedAt();
-                break;
-            case 7:
-                return $this->getVersionCreatedBy();
-                break;
             default:
                 return null;
                 break;
@@ -1352,9 +1112,6 @@ abstract class Person implements ActiveRecordInterface
             $keys[2] => $this->getLastName(),
             $keys[3] => $this->getCreatedAt(),
             $keys[4] => $this->getUpdatedAt(),
-            $keys[5] => $this->getVersion(),
-            $keys[6] => $this->getVersionCreatedAt(),
-            $keys[7] => $this->getVersionCreatedBy(),
         );
         $virtualColumns = $this->virtualColumns;
         foreach ($virtualColumns as $key => $virtualColumn) {
@@ -1373,9 +1130,6 @@ abstract class Person implements ActiveRecordInterface
             }
             if (null !== $this->collPersonI18ns) {
                 $result['PersonI18ns'] = $this->collPersonI18ns->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
-            }
-            if (null !== $this->collPersonVersions) {
-                $result['PersonVersions'] = $this->collPersonVersions->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
             }
         }
 
@@ -1426,15 +1180,6 @@ abstract class Person implements ActiveRecordInterface
             case 4:
                 $this->setUpdatedAt($value);
                 break;
-            case 5:
-                $this->setVersion($value);
-                break;
-            case 6:
-                $this->setVersionCreatedAt($value);
-                break;
-            case 7:
-                $this->setVersionCreatedBy($value);
-                break;
         } // switch()
     }
 
@@ -1464,9 +1209,6 @@ abstract class Person implements ActiveRecordInterface
         if (array_key_exists($keys[2], $arr)) $this->setLastName($arr[$keys[2]]);
         if (array_key_exists($keys[3], $arr)) $this->setCreatedAt($arr[$keys[3]]);
         if (array_key_exists($keys[4], $arr)) $this->setUpdatedAt($arr[$keys[4]]);
-        if (array_key_exists($keys[5], $arr)) $this->setVersion($arr[$keys[5]]);
-        if (array_key_exists($keys[6], $arr)) $this->setVersionCreatedAt($arr[$keys[6]]);
-        if (array_key_exists($keys[7], $arr)) $this->setVersionCreatedBy($arr[$keys[7]]);
     }
 
     /**
@@ -1483,9 +1225,6 @@ abstract class Person implements ActiveRecordInterface
         if ($this->isColumnModified(PersonTableMap::LAST_NAME)) $criteria->add(PersonTableMap::LAST_NAME, $this->last_name);
         if ($this->isColumnModified(PersonTableMap::CREATED_AT)) $criteria->add(PersonTableMap::CREATED_AT, $this->created_at);
         if ($this->isColumnModified(PersonTableMap::UPDATED_AT)) $criteria->add(PersonTableMap::UPDATED_AT, $this->updated_at);
-        if ($this->isColumnModified(PersonTableMap::VERSION)) $criteria->add(PersonTableMap::VERSION, $this->version);
-        if ($this->isColumnModified(PersonTableMap::VERSION_CREATED_AT)) $criteria->add(PersonTableMap::VERSION_CREATED_AT, $this->version_created_at);
-        if ($this->isColumnModified(PersonTableMap::VERSION_CREATED_BY)) $criteria->add(PersonTableMap::VERSION_CREATED_BY, $this->version_created_by);
 
         return $criteria;
     }
@@ -1553,9 +1292,6 @@ abstract class Person implements ActiveRecordInterface
         $copyObj->setLastName($this->getLastName());
         $copyObj->setCreatedAt($this->getCreatedAt());
         $copyObj->setUpdatedAt($this->getUpdatedAt());
-        $copyObj->setVersion($this->getVersion());
-        $copyObj->setVersionCreatedAt($this->getVersionCreatedAt());
-        $copyObj->setVersionCreatedBy($this->getVersionCreatedBy());
 
         if ($deepCopy) {
             // important: temporarily setNew(false) because this affects the behavior of
@@ -1583,12 +1319,6 @@ abstract class Person implements ActiveRecordInterface
             foreach ($this->getPersonI18ns() as $relObj) {
                 if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
                     $copyObj->addPersonI18n($relObj->copy($deepCopy));
-                }
-            }
-
-            foreach ($this->getPersonVersions() as $relObj) {
-                if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
-                    $copyObj->addPersonVersion($relObj->copy($deepCopy));
                 }
             }
 
@@ -1644,9 +1374,6 @@ abstract class Person implements ActiveRecordInterface
         }
         if ('PersonI18n' == $relationName) {
             return $this->initPersonI18ns();
-        }
-        if ('PersonVersion' == $relationName) {
-            return $this->initPersonVersions();
         }
     }
 
@@ -2580,227 +2307,6 @@ abstract class Person implements ActiveRecordInterface
     }
 
     /**
-     * Clears out the collPersonVersions collection
-     *
-     * This does not modify the database; however, it will remove any associated objects, causing
-     * them to be refetched by subsequent calls to accessor method.
-     *
-     * @return void
-     * @see        addPersonVersions()
-     */
-    public function clearPersonVersions()
-    {
-        $this->collPersonVersions = null; // important to set this to NULL since that means it is uninitialized
-    }
-
-    /**
-     * Reset is the collPersonVersions collection loaded partially.
-     */
-    public function resetPartialPersonVersions($v = true)
-    {
-        $this->collPersonVersionsPartial = $v;
-    }
-
-    /**
-     * Initializes the collPersonVersions collection.
-     *
-     * By default this just sets the collPersonVersions collection to an empty array (like clearcollPersonVersions());
-     * however, you may wish to override this method in your stub class to provide setting appropriate
-     * to your application -- for example, setting the initial array to the values stored in database.
-     *
-     * @param      boolean $overrideExisting If set to true, the method call initializes
-     *                                        the collection even if it is not empty
-     *
-     * @return void
-     */
-    public function initPersonVersions($overrideExisting = true)
-    {
-        if (null !== $this->collPersonVersions && !$overrideExisting) {
-            return;
-        }
-        $this->collPersonVersions = new ObjectCollection();
-        $this->collPersonVersions->setModel('\Team\Model\PersonVersion');
-    }
-
-    /**
-     * Gets an array of ChildPersonVersion objects which contain a foreign key that references this object.
-     *
-     * If the $criteria is not null, it is used to always fetch the results from the database.
-     * Otherwise the results are fetched from the database the first time, then cached.
-     * Next time the same method is called without $criteria, the cached collection is returned.
-     * If this ChildPerson is new, it will return
-     * an empty collection or the current collection; the criteria is ignored on a new object.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @return Collection|ChildPersonVersion[] List of ChildPersonVersion objects
-     * @throws PropelException
-     */
-    public function getPersonVersions($criteria = null, ConnectionInterface $con = null)
-    {
-        $partial = $this->collPersonVersionsPartial && !$this->isNew();
-        if (null === $this->collPersonVersions || null !== $criteria  || $partial) {
-            if ($this->isNew() && null === $this->collPersonVersions) {
-                // return empty collection
-                $this->initPersonVersions();
-            } else {
-                $collPersonVersions = ChildPersonVersionQuery::create(null, $criteria)
-                    ->filterByPerson($this)
-                    ->find($con);
-
-                if (null !== $criteria) {
-                    if (false !== $this->collPersonVersionsPartial && count($collPersonVersions)) {
-                        $this->initPersonVersions(false);
-
-                        foreach ($collPersonVersions as $obj) {
-                            if (false == $this->collPersonVersions->contains($obj)) {
-                                $this->collPersonVersions->append($obj);
-                            }
-                        }
-
-                        $this->collPersonVersionsPartial = true;
-                    }
-
-                    reset($collPersonVersions);
-
-                    return $collPersonVersions;
-                }
-
-                if ($partial && $this->collPersonVersions) {
-                    foreach ($this->collPersonVersions as $obj) {
-                        if ($obj->isNew()) {
-                            $collPersonVersions[] = $obj;
-                        }
-                    }
-                }
-
-                $this->collPersonVersions = $collPersonVersions;
-                $this->collPersonVersionsPartial = false;
-            }
-        }
-
-        return $this->collPersonVersions;
-    }
-
-    /**
-     * Sets a collection of PersonVersion objects related by a one-to-many relationship
-     * to the current object.
-     * It will also schedule objects for deletion based on a diff between old objects (aka persisted)
-     * and new objects from the given Propel collection.
-     *
-     * @param      Collection $personVersions A Propel collection.
-     * @param      ConnectionInterface $con Optional connection object
-     * @return   ChildPerson The current object (for fluent API support)
-     */
-    public function setPersonVersions(Collection $personVersions, ConnectionInterface $con = null)
-    {
-        $personVersionsToDelete = $this->getPersonVersions(new Criteria(), $con)->diff($personVersions);
-
-
-        //since at least one column in the foreign key is at the same time a PK
-        //we can not just set a PK to NULL in the lines below. We have to store
-        //a backup of all values, so we are able to manipulate these items based on the onDelete value later.
-        $this->personVersionsScheduledForDeletion = clone $personVersionsToDelete;
-
-        foreach ($personVersionsToDelete as $personVersionRemoved) {
-            $personVersionRemoved->setPerson(null);
-        }
-
-        $this->collPersonVersions = null;
-        foreach ($personVersions as $personVersion) {
-            $this->addPersonVersion($personVersion);
-        }
-
-        $this->collPersonVersions = $personVersions;
-        $this->collPersonVersionsPartial = false;
-
-        return $this;
-    }
-
-    /**
-     * Returns the number of related PersonVersion objects.
-     *
-     * @param      Criteria $criteria
-     * @param      boolean $distinct
-     * @param      ConnectionInterface $con
-     * @return int             Count of related PersonVersion objects.
-     * @throws PropelException
-     */
-    public function countPersonVersions(Criteria $criteria = null, $distinct = false, ConnectionInterface $con = null)
-    {
-        $partial = $this->collPersonVersionsPartial && !$this->isNew();
-        if (null === $this->collPersonVersions || null !== $criteria || $partial) {
-            if ($this->isNew() && null === $this->collPersonVersions) {
-                return 0;
-            }
-
-            if ($partial && !$criteria) {
-                return count($this->getPersonVersions());
-            }
-
-            $query = ChildPersonVersionQuery::create(null, $criteria);
-            if ($distinct) {
-                $query->distinct();
-            }
-
-            return $query
-                ->filterByPerson($this)
-                ->count($con);
-        }
-
-        return count($this->collPersonVersions);
-    }
-
-    /**
-     * Method called to associate a ChildPersonVersion object to this object
-     * through the ChildPersonVersion foreign key attribute.
-     *
-     * @param    ChildPersonVersion $l ChildPersonVersion
-     * @return   \Team\Model\Person The current object (for fluent API support)
-     */
-    public function addPersonVersion(ChildPersonVersion $l)
-    {
-        if ($this->collPersonVersions === null) {
-            $this->initPersonVersions();
-            $this->collPersonVersionsPartial = true;
-        }
-
-        if (!in_array($l, $this->collPersonVersions->getArrayCopy(), true)) { // only add it if the **same** object is not already associated
-            $this->doAddPersonVersion($l);
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param PersonVersion $personVersion The personVersion object to add.
-     */
-    protected function doAddPersonVersion($personVersion)
-    {
-        $this->collPersonVersions[]= $personVersion;
-        $personVersion->setPerson($this);
-    }
-
-    /**
-     * @param  PersonVersion $personVersion The personVersion object to remove.
-     * @return ChildPerson The current object (for fluent API support)
-     */
-    public function removePersonVersion($personVersion)
-    {
-        if ($this->getPersonVersions()->contains($personVersion)) {
-            $this->collPersonVersions->remove($this->collPersonVersions->search($personVersion));
-            if (null === $this->personVersionsScheduledForDeletion) {
-                $this->personVersionsScheduledForDeletion = clone $this->collPersonVersions;
-                $this->personVersionsScheduledForDeletion->clear();
-            }
-            $this->personVersionsScheduledForDeletion[]= clone $personVersion;
-            $personVersion->setPerson(null);
-        }
-
-        return $this;
-    }
-
-    /**
      * Clears the current object and sets all attributes to their default values
      */
     public function clear()
@@ -2810,12 +2316,8 @@ abstract class Person implements ActiveRecordInterface
         $this->last_name = null;
         $this->created_at = null;
         $this->updated_at = null;
-        $this->version = null;
-        $this->version_created_at = null;
-        $this->version_created_by = null;
         $this->alreadyInSave = false;
         $this->clearAllReferences();
-        $this->applyDefaultValues();
         $this->resetModified();
         $this->setNew(true);
         $this->setDeleted(false);
@@ -2853,11 +2355,6 @@ abstract class Person implements ActiveRecordInterface
                     $o->clearAllReferences($deep);
                 }
             }
-            if ($this->collPersonVersions) {
-                foreach ($this->collPersonVersions as $o) {
-                    $o->clearAllReferences($deep);
-                }
-            }
         } // if ($deep)
 
         // i18n behavior
@@ -2868,7 +2365,6 @@ abstract class Person implements ActiveRecordInterface
         $this->collPersonImages = null;
         $this->collPersonFunctionLinks = null;
         $this->collPersonI18ns = null;
-        $this->collPersonVersions = null;
     }
 
     /**
@@ -3018,399 +2514,6 @@ abstract class Person implements ActiveRecordInterface
         return $this;
     }
 
-    // versionable behavior
-
-    /**
-     * Enforce a new Version of this object upon next save.
-     *
-     * @return \Team\Model\Person
-     */
-    public function enforceVersioning()
-    {
-        $this->enforceVersion = true;
-
-        return $this;
-    }
-
-    /**
-     * Checks whether the current state must be recorded as a version
-     *
-     * @return  boolean
-     */
-    public function isVersioningNecessary($con = null)
-    {
-        if ($this->alreadyInSave) {
-            return false;
-        }
-
-        if ($this->enforceVersion) {
-            return true;
-        }
-
-        if (ChildPersonQuery::isVersioningEnabled() && ($this->isNew() || $this->isModified()) || $this->isDeleted()) {
-            return true;
-        }
-        // to avoid infinite loops, emulate in save
-        $this->alreadyInSave = true;
-        foreach ($this->getPersonTeamLinks(null, $con) as $relatedObject) {
-            if ($relatedObject->isVersioningNecessary($con)) {
-                $this->alreadyInSave = false;
-
-                return true;
-            }
-        }
-        $this->alreadyInSave = false;
-
-        // to avoid infinite loops, emulate in save
-        $this->alreadyInSave = true;
-        foreach ($this->getPersonImages(null, $con) as $relatedObject) {
-            if ($relatedObject->isVersioningNecessary($con)) {
-                $this->alreadyInSave = false;
-
-                return true;
-            }
-        }
-        $this->alreadyInSave = false;
-
-        // to avoid infinite loops, emulate in save
-        $this->alreadyInSave = true;
-        foreach ($this->getPersonFunctionLinks(null, $con) as $relatedObject) {
-            if ($relatedObject->isVersioningNecessary($con)) {
-                $this->alreadyInSave = false;
-
-                return true;
-            }
-        }
-        $this->alreadyInSave = false;
-
-
-        return false;
-    }
-
-    /**
-     * Creates a version of the current object and saves it.
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ChildPersonVersion A version object
-     */
-    public function addVersion($con = null)
-    {
-        $this->enforceVersion = false;
-
-        $version = new ChildPersonVersion();
-        $version->setId($this->getId());
-        $version->setFirstName($this->getFirstName());
-        $version->setLastName($this->getLastName());
-        $version->setCreatedAt($this->getCreatedAt());
-        $version->setUpdatedAt($this->getUpdatedAt());
-        $version->setVersion($this->getVersion());
-        $version->setVersionCreatedAt($this->getVersionCreatedAt());
-        $version->setVersionCreatedBy($this->getVersionCreatedBy());
-        $version->setPerson($this);
-        if ($relateds = $this->getPersonTeamLinks($con)->toKeyValue('Id', 'Version')) {
-            $version->setPersonTeamLinkIds(array_keys($relateds));
-            $version->setPersonTeamLinkVersions(array_values($relateds));
-        }
-        if ($relateds = $this->getPersonImages($con)->toKeyValue('Id', 'Version')) {
-            $version->setPersonImageIds(array_keys($relateds));
-            $version->setPersonImageVersions(array_values($relateds));
-        }
-        if ($relateds = $this->getPersonFunctionLinks($con)->toKeyValue('Id', 'Version')) {
-            $version->setPersonFunctionLinkIds(array_keys($relateds));
-            $version->setPersonFunctionLinkVersions(array_values($relateds));
-        }
-        $version->save($con);
-
-        return $version;
-    }
-
-    /**
-     * Sets the properties of the current object to the value they had at a specific version
-     *
-     * @param   integer $versionNumber The version number to read
-     * @param   ConnectionInterface $con The connection to use
-     *
-     * @return  ChildPerson The current object (for fluent API support)
-     */
-    public function toVersion($versionNumber, $con = null)
-    {
-        $version = $this->getOneVersion($versionNumber, $con);
-        if (!$version) {
-            throw new PropelException(sprintf('No ChildPerson object found with version %d', $version));
-        }
-        $this->populateFromVersion($version, $con);
-
-        return $this;
-    }
-
-    /**
-     * Sets the properties of the current object to the value they had at a specific version
-     *
-     * @param ChildPersonVersion $version The version object to use
-     * @param ConnectionInterface   $con the connection to use
-     * @param array                 $loadedObjects objects that been loaded in a chain of populateFromVersion calls on referrer or fk objects.
-     *
-     * @return ChildPerson The current object (for fluent API support)
-     */
-    public function populateFromVersion($version, $con = null, &$loadedObjects = array())
-    {
-        $loadedObjects['ChildPerson'][$version->getId()][$version->getVersion()] = $this;
-        $this->setId($version->getId());
-        $this->setFirstName($version->getFirstName());
-        $this->setLastName($version->getLastName());
-        $this->setCreatedAt($version->getCreatedAt());
-        $this->setUpdatedAt($version->getUpdatedAt());
-        $this->setVersion($version->getVersion());
-        $this->setVersionCreatedAt($version->getVersionCreatedAt());
-        $this->setVersionCreatedBy($version->getVersionCreatedBy());
-        if ($fkValues = $version->getPersonTeamLinkIds()) {
-            $this->clearPersonTeamLinks();
-            $fkVersions = $version->getPersonTeamLinkVersions();
-            $query = ChildPersonTeamLinkVersionQuery::create();
-            foreach ($fkValues as $key => $value) {
-                $c1 = $query->getNewCriterion(PersonTeamLinkVersionTableMap::ID, $value);
-                $c2 = $query->getNewCriterion(PersonTeamLinkVersionTableMap::VERSION, $fkVersions[$key]);
-                $c1->addAnd($c2);
-                $query->addOr($c1);
-            }
-            foreach ($query->find($con) as $relatedVersion) {
-                if (isset($loadedObjects['ChildPersonTeamLink']) && isset($loadedObjects['ChildPersonTeamLink'][$relatedVersion->getId()]) && isset($loadedObjects['ChildPersonTeamLink'][$relatedVersion->getId()][$relatedVersion->getVersion()])) {
-                    $related = $loadedObjects['ChildPersonTeamLink'][$relatedVersion->getId()][$relatedVersion->getVersion()];
-                } else {
-                    $related = new ChildPersonTeamLink();
-                    $related->populateFromVersion($relatedVersion, $con, $loadedObjects);
-                    $related->setNew(false);
-                }
-                $this->addPersonTeamLink($related);
-                $this->collPersonTeamLinksPartial = false;
-            }
-        }
-        if ($fkValues = $version->getPersonImageIds()) {
-            $this->clearPersonImage();
-            $fkVersions = $version->getPersonImageVersions();
-            $query = ChildPersonImageVersionQuery::create();
-            foreach ($fkValues as $key => $value) {
-                $c1 = $query->getNewCriterion(PersonImageVersionTableMap::ID, $value);
-                $c2 = $query->getNewCriterion(PersonImageVersionTableMap::VERSION, $fkVersions[$key]);
-                $c1->addAnd($c2);
-                $query->addOr($c1);
-            }
-            foreach ($query->find($con) as $relatedVersion) {
-                if (isset($loadedObjects['ChildPersonImage']) && isset($loadedObjects['ChildPersonImage'][$relatedVersion->getId()]) && isset($loadedObjects['ChildPersonImage'][$relatedVersion->getId()][$relatedVersion->getVersion()])) {
-                    $related = $loadedObjects['ChildPersonImage'][$relatedVersion->getId()][$relatedVersion->getVersion()];
-                } else {
-                    $related = new ChildPersonImage();
-                    $related->populateFromVersion($relatedVersion, $con, $loadedObjects);
-                    $related->setNew(false);
-                }
-                $this->addPersonImage($related);
-                $this->collPersonImagePartial = false;
-            }
-        }
-        if ($fkValues = $version->getPersonFunctionLinkIds()) {
-            $this->clearPersonFunctionLink();
-            $fkVersions = $version->getPersonFunctionLinkVersions();
-            $query = ChildPersonFunctionLinkVersionQuery::create();
-            foreach ($fkValues as $key => $value) {
-                $c1 = $query->getNewCriterion(PersonFunctionLinkVersionTableMap::ID, $value);
-                $c2 = $query->getNewCriterion(PersonFunctionLinkVersionTableMap::VERSION, $fkVersions[$key]);
-                $c1->addAnd($c2);
-                $query->addOr($c1);
-            }
-            foreach ($query->find($con) as $relatedVersion) {
-                if (isset($loadedObjects['ChildPersonFunctionLink']) && isset($loadedObjects['ChildPersonFunctionLink'][$relatedVersion->getId()]) && isset($loadedObjects['ChildPersonFunctionLink'][$relatedVersion->getId()][$relatedVersion->getVersion()])) {
-                    $related = $loadedObjects['ChildPersonFunctionLink'][$relatedVersion->getId()][$relatedVersion->getVersion()];
-                } else {
-                    $related = new ChildPersonFunctionLink();
-                    $related->populateFromVersion($relatedVersion, $con, $loadedObjects);
-                    $related->setNew(false);
-                }
-                $this->addPersonFunctionLink($related);
-                $this->collPersonFunctionLinkPartial = false;
-            }
-        }
-
-        return $this;
-    }
-
-    /**
-     * Gets the latest persisted version number for the current object
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  integer
-     */
-    public function getLastVersionNumber($con = null)
-    {
-        $v = ChildPersonVersionQuery::create()
-            ->filterByPerson($this)
-            ->orderByVersion('desc')
-            ->findOne($con);
-        if (!$v) {
-            return 0;
-        }
-
-        return $v->getVersion();
-    }
-
-    /**
-     * Checks whether the current object is the latest one
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  Boolean
-     */
-    public function isLastVersion($con = null)
-    {
-        return $this->getLastVersionNumber($con) == $this->getVersion();
-    }
-
-    /**
-     * Retrieves a version object for this entity and a version number
-     *
-     * @param   integer $versionNumber The version number to read
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ChildPersonVersion A version object
-     */
-    public function getOneVersion($versionNumber, $con = null)
-    {
-        return ChildPersonVersionQuery::create()
-            ->filterByPerson($this)
-            ->filterByVersion($versionNumber)
-            ->findOne($con);
-    }
-
-    /**
-     * Gets all the versions of this object, in incremental order
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ObjectCollection A list of ChildPersonVersion objects
-     */
-    public function getAllVersions($con = null)
-    {
-        $criteria = new Criteria();
-        $criteria->addAscendingOrderByColumn(PersonVersionTableMap::VERSION);
-
-        return $this->getPersonVersions($criteria, $con);
-    }
-
-    /**
-     * Compares the current object with another of its version.
-     * <code>
-     * print_r($book->compareVersion(1));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   integer             $versionNumber
-     * @param   string              $keys Main key used for the result diff (versions|columns)
-     * @param   ConnectionInterface $con the connection to use
-     * @param   array               $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    public function compareVersion($versionNumber, $keys = 'columns', $con = null, $ignoredColumns = array())
-    {
-        $fromVersion = $this->toArray();
-        $toVersion = $this->getOneVersion($versionNumber, $con)->toArray();
-
-        return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
-    }
-
-    /**
-     * Compares two versions of the current object.
-     * <code>
-     * print_r($book->compareVersions(1, 2));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   integer             $fromVersionNumber
-     * @param   integer             $toVersionNumber
-     * @param   string              $keys Main key used for the result diff (versions|columns)
-     * @param   ConnectionInterface $con the connection to use
-     * @param   array               $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    public function compareVersions($fromVersionNumber, $toVersionNumber, $keys = 'columns', $con = null, $ignoredColumns = array())
-    {
-        $fromVersion = $this->getOneVersion($fromVersionNumber, $con)->toArray();
-        $toVersion = $this->getOneVersion($toVersionNumber, $con)->toArray();
-
-        return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
-    }
-
-    /**
-     * Computes the diff between two versions.
-     * <code>
-     * print_r($book->computeDiff(1, 2));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   array     $fromVersion     An array representing the original version.
-     * @param   array     $toVersion       An array representing the destination version.
-     * @param   string    $keys            Main key used for the result diff (versions|columns).
-     * @param   array     $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    protected function computeDiff($fromVersion, $toVersion, $keys = 'columns', $ignoredColumns = array())
-    {
-        $fromVersionNumber = $fromVersion['Version'];
-        $toVersionNumber = $toVersion['Version'];
-        $ignoredColumns = array_merge(array(
-            'Version',
-            'VersionCreatedAt',
-            'VersionCreatedBy',
-        ), $ignoredColumns);
-        $diff = array();
-        foreach ($fromVersion as $key => $value) {
-            if (in_array($key, $ignoredColumns)) {
-                continue;
-            }
-            if ($toVersion[$key] != $value) {
-                switch ($keys) {
-                    case 'versions':
-                        $diff[$fromVersionNumber][$key] = $value;
-                        $diff[$toVersionNumber][$key] = $toVersion[$key];
-                        break;
-                    default:
-                        $diff[$key] = array(
-                            $fromVersionNumber => $value,
-                            $toVersionNumber => $toVersion[$key],
-                        );
-                        break;
-                }
-            }
-        }
-
-        return $diff;
-    }
-    /**
-     * retrieve the last $number versions.
-     *
-     * @param Integer $number the number of record to return.
-     * @return PropelCollection|array \Team\Model\PersonVersion[] List of \Team\Model\PersonVersion objects
-     */
-    public function getLastVersions($number = 10, $criteria = null, $con = null)
-    {
-        $criteria = ChildPersonVersionQuery::create(null, $criteria);
-        $criteria->addDescendingOrderByColumn(PersonVersionTableMap::VERSION);
-        $criteria->limit($number);
-
-        return $this->getPersonVersions($criteria, $con);
-    }
     /**
      * Code to be run before persisting the object
      * @param  ConnectionInterface $con

--- a/Model/Base/PersonFunction.php
+++ b/Model/Base/PersonFunction.php
@@ -22,13 +22,8 @@ use Team\Model\PersonFunctionI18n as ChildPersonFunctionI18n;
 use Team\Model\PersonFunctionI18nQuery as ChildPersonFunctionI18nQuery;
 use Team\Model\PersonFunctionLink as ChildPersonFunctionLink;
 use Team\Model\PersonFunctionLinkQuery as ChildPersonFunctionLinkQuery;
-use Team\Model\PersonFunctionLinkVersionQuery as ChildPersonFunctionLinkVersionQuery;
 use Team\Model\PersonFunctionQuery as ChildPersonFunctionQuery;
-use Team\Model\PersonFunctionVersion as ChildPersonFunctionVersion;
-use Team\Model\PersonFunctionVersionQuery as ChildPersonFunctionVersionQuery;
-use Team\Model\Map\PersonFunctionLinkVersionTableMap;
 use Team\Model\Map\PersonFunctionTableMap;
-use Team\Model\Map\PersonFunctionVersionTableMap;
 
 abstract class PersonFunction implements ActiveRecordInterface
 {
@@ -89,25 +84,6 @@ abstract class PersonFunction implements ActiveRecordInterface
     protected $updated_at;
 
     /**
-     * The value for the version field.
-     * Note: this column has a database default value of: 0
-     * @var        int
-     */
-    protected $version;
-
-    /**
-     * The value for the version_created_at field.
-     * @var        string
-     */
-    protected $version_created_at;
-
-    /**
-     * The value for the version_created_by field.
-     * @var        string
-     */
-    protected $version_created_by;
-
-    /**
      * @var        ObjectCollection|ChildPersonFunctionLink[] Collection to store aggregation of ChildPersonFunctionLink objects.
      */
     protected $collPersonFunctionLinks;
@@ -118,12 +94,6 @@ abstract class PersonFunction implements ActiveRecordInterface
      */
     protected $collPersonFunctionI18ns;
     protected $collPersonFunctionI18nsPartial;
-
-    /**
-     * @var        ObjectCollection|ChildPersonFunctionVersion[] Collection to store aggregation of ChildPersonFunctionVersion objects.
-     */
-    protected $collPersonFunctionVersions;
-    protected $collPersonFunctionVersionsPartial;
 
     /**
      * Flag to prevent endless save loop, if this object is referenced
@@ -147,14 +117,6 @@ abstract class PersonFunction implements ActiveRecordInterface
      */
     protected $currentTranslations;
 
-    // versionable behavior
-
-
-    /**
-     * @var bool
-     */
-    protected $enforceVersion = false;
-
     /**
      * An array of objects scheduled for deletion.
      * @var ObjectCollection
@@ -168,29 +130,10 @@ abstract class PersonFunction implements ActiveRecordInterface
     protected $personFunctionI18nsScheduledForDeletion = null;
 
     /**
-     * An array of objects scheduled for deletion.
-     * @var ObjectCollection
-     */
-    protected $personFunctionVersionsScheduledForDeletion = null;
-
-    /**
-     * Applies default values to this object.
-     * This method should be called from the object's constructor (or
-     * equivalent initialization method).
-     * @see __construct()
-     */
-    public function applyDefaultValues()
-    {
-        $this->version = 0;
-    }
-
-    /**
      * Initializes internal state of Team\Model\Base\PersonFunction object.
-     * @see applyDefaults()
      */
     public function __construct()
     {
-        $this->applyDefaultValues();
     }
 
     /**
@@ -507,48 +450,6 @@ abstract class PersonFunction implements ActiveRecordInterface
     }
 
     /**
-     * Get the [version] column value.
-     *
-     * @return   int
-     */
-    public function getVersion()
-    {
-
-        return $this->version;
-    }
-
-    /**
-     * Get the [optionally formatted] temporal [version_created_at] column value.
-     *
-     *
-     * @param      string $format The date/time format string (either date()-style or strftime()-style).
-     *                            If format is NULL, then the raw \DateTime object will be returned.
-     *
-     * @return mixed Formatted date/time value as string or \DateTime object (if format is NULL), NULL if column is NULL, and 0 if column value is 0000-00-00 00:00:00
-     *
-     * @throws PropelException - if unable to parse/validate the date/time value.
-     */
-    public function getVersionCreatedAt($format = NULL)
-    {
-        if ($format === null) {
-            return $this->version_created_at;
-        } else {
-            return $this->version_created_at instanceof \DateTime ? $this->version_created_at->format($format) : null;
-        }
-    }
-
-    /**
-     * Get the [version_created_by] column value.
-     *
-     * @return   string
-     */
-    public function getVersionCreatedBy()
-    {
-
-        return $this->version_created_by;
-    }
-
-    /**
      * Set the value of [id] column.
      *
      * @param      int $v new value
@@ -633,69 +534,6 @@ abstract class PersonFunction implements ActiveRecordInterface
     } // setUpdatedAt()
 
     /**
-     * Set the value of [version] column.
-     *
-     * @param      int $v new value
-     * @return   \Team\Model\PersonFunction The current object (for fluent API support)
-     */
-    public function setVersion($v)
-    {
-        if ($v !== null) {
-            $v = (int) $v;
-        }
-
-        if ($this->version !== $v) {
-            $this->version = $v;
-            $this->modifiedColumns[PersonFunctionTableMap::VERSION] = true;
-        }
-
-
-        return $this;
-    } // setVersion()
-
-    /**
-     * Sets the value of [version_created_at] column to a normalized version of the date/time value specified.
-     *
-     * @param      mixed $v string, integer (timestamp), or \DateTime value.
-     *               Empty strings are treated as NULL.
-     * @return   \Team\Model\PersonFunction The current object (for fluent API support)
-     */
-    public function setVersionCreatedAt($v)
-    {
-        $dt = PropelDateTime::newInstance($v, null, '\DateTime');
-        if ($this->version_created_at !== null || $dt !== null) {
-            if ($dt !== $this->version_created_at) {
-                $this->version_created_at = $dt;
-                $this->modifiedColumns[PersonFunctionTableMap::VERSION_CREATED_AT] = true;
-            }
-        } // if either are not null
-
-
-        return $this;
-    } // setVersionCreatedAt()
-
-    /**
-     * Set the value of [version_created_by] column.
-     *
-     * @param      string $v new value
-     * @return   \Team\Model\PersonFunction The current object (for fluent API support)
-     */
-    public function setVersionCreatedBy($v)
-    {
-        if ($v !== null) {
-            $v = (string) $v;
-        }
-
-        if ($this->version_created_by !== $v) {
-            $this->version_created_by = $v;
-            $this->modifiedColumns[PersonFunctionTableMap::VERSION_CREATED_BY] = true;
-        }
-
-
-        return $this;
-    } // setVersionCreatedBy()
-
-    /**
      * Indicates whether the columns in this object are only set to default values.
      *
      * This method can be used in conjunction with isModified() to indicate whether an object is both
@@ -705,10 +543,6 @@ abstract class PersonFunction implements ActiveRecordInterface
      */
     public function hasOnlyDefaultValues()
     {
-            if ($this->version !== 0) {
-                return false;
-            }
-
         // otherwise, everything was equal, so return TRUE
         return true;
     } // hasOnlyDefaultValues()
@@ -753,18 +587,6 @@ abstract class PersonFunction implements ActiveRecordInterface
                 $col = null;
             }
             $this->updated_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 4 + $startcol : PersonFunctionTableMap::translateFieldName('Version', TableMap::TYPE_PHPNAME, $indexType)];
-            $this->version = (null !== $col) ? (int) $col : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : PersonFunctionTableMap::translateFieldName('VersionCreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
-            if ($col === '0000-00-00 00:00:00') {
-                $col = null;
-            }
-            $this->version_created_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : PersonFunctionTableMap::translateFieldName('VersionCreatedBy', TableMap::TYPE_PHPNAME, $indexType)];
-            $this->version_created_by = (null !== $col) ? (string) $col : null;
             $this->resetModified();
 
             $this->setNew(false);
@@ -773,7 +595,7 @@ abstract class PersonFunction implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 7; // 7 = PersonFunctionTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 4; // 4 = PersonFunctionTableMap::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception $e) {
             throw new PropelException("Error populating \Team\Model\PersonFunction object", 0, $e);
@@ -837,8 +659,6 @@ abstract class PersonFunction implements ActiveRecordInterface
             $this->collPersonFunctionLinks = null;
 
             $this->collPersonFunctionI18ns = null;
-
-            $this->collPersonFunctionVersions = null;
 
         } // if (deep)
     }
@@ -908,14 +728,6 @@ abstract class PersonFunction implements ActiveRecordInterface
         $isInsert = $this->isNew();
         try {
             $ret = $this->preSave($con);
-            // versionable behavior
-            if ($this->isVersioningNecessary()) {
-                $this->setVersion($this->isNew() ? 1 : $this->getLastVersionNumber($con) + 1);
-                if (!$this->isColumnModified(PersonFunctionTableMap::VERSION_CREATED_AT)) {
-                    $this->setVersionCreatedAt(time());
-                }
-                $createVersion = true; // for postSave hook
-            }
             if ($isInsert) {
                 $ret = $ret && $this->preInsert($con);
                 // timestampable behavior
@@ -940,10 +752,6 @@ abstract class PersonFunction implements ActiveRecordInterface
                     $this->postUpdate($con);
                 }
                 $this->postSave($con);
-                // versionable behavior
-                if (isset($createVersion)) {
-                    $this->addVersion($con);
-                }
                 PersonFunctionTableMap::addInstanceToPool($this);
             } else {
                 $affectedRows = 0;
@@ -1019,23 +827,6 @@ abstract class PersonFunction implements ActiveRecordInterface
                 }
             }
 
-            if ($this->personFunctionVersionsScheduledForDeletion !== null) {
-                if (!$this->personFunctionVersionsScheduledForDeletion->isEmpty()) {
-                    \Team\Model\PersonFunctionVersionQuery::create()
-                        ->filterByPrimaryKeys($this->personFunctionVersionsScheduledForDeletion->getPrimaryKeys(false))
-                        ->delete($con);
-                    $this->personFunctionVersionsScheduledForDeletion = null;
-                }
-            }
-
-                if ($this->collPersonFunctionVersions !== null) {
-            foreach ($this->collPersonFunctionVersions as $referrerFK) {
-                    if (!$referrerFK->isDeleted() && ($referrerFK->isNew() || $referrerFK->isModified())) {
-                        $affectedRows += $referrerFK->save($con);
-                    }
-                }
-            }
-
             $this->alreadyInSave = false;
 
         }
@@ -1074,15 +865,6 @@ abstract class PersonFunction implements ActiveRecordInterface
         if ($this->isColumnModified(PersonFunctionTableMap::UPDATED_AT)) {
             $modifiedColumns[':p' . $index++]  = 'UPDATED_AT';
         }
-        if ($this->isColumnModified(PersonFunctionTableMap::VERSION)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION';
-        }
-        if ($this->isColumnModified(PersonFunctionTableMap::VERSION_CREATED_AT)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION_CREATED_AT';
-        }
-        if ($this->isColumnModified(PersonFunctionTableMap::VERSION_CREATED_BY)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION_CREATED_BY';
-        }
 
         $sql = sprintf(
             'INSERT INTO person_function (%s) VALUES (%s)',
@@ -1105,15 +887,6 @@ abstract class PersonFunction implements ActiveRecordInterface
                         break;
                     case 'UPDATED_AT':
                         $stmt->bindValue($identifier, $this->updated_at ? $this->updated_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
-                        break;
-                    case 'VERSION':
-                        $stmt->bindValue($identifier, $this->version, PDO::PARAM_INT);
-                        break;
-                    case 'VERSION_CREATED_AT':
-                        $stmt->bindValue($identifier, $this->version_created_at ? $this->version_created_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
-                        break;
-                    case 'VERSION_CREATED_BY':
-                        $stmt->bindValue($identifier, $this->version_created_by, PDO::PARAM_STR);
                         break;
                 }
             }
@@ -1189,15 +962,6 @@ abstract class PersonFunction implements ActiveRecordInterface
             case 3:
                 return $this->getUpdatedAt();
                 break;
-            case 4:
-                return $this->getVersion();
-                break;
-            case 5:
-                return $this->getVersionCreatedAt();
-                break;
-            case 6:
-                return $this->getVersionCreatedBy();
-                break;
             default:
                 return null;
                 break;
@@ -1231,9 +995,6 @@ abstract class PersonFunction implements ActiveRecordInterface
             $keys[1] => $this->getCode(),
             $keys[2] => $this->getCreatedAt(),
             $keys[3] => $this->getUpdatedAt(),
-            $keys[4] => $this->getVersion(),
-            $keys[5] => $this->getVersionCreatedAt(),
-            $keys[6] => $this->getVersionCreatedBy(),
         );
         $virtualColumns = $this->virtualColumns;
         foreach ($virtualColumns as $key => $virtualColumn) {
@@ -1246,9 +1007,6 @@ abstract class PersonFunction implements ActiveRecordInterface
             }
             if (null !== $this->collPersonFunctionI18ns) {
                 $result['PersonFunctionI18ns'] = $this->collPersonFunctionI18ns->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
-            }
-            if (null !== $this->collPersonFunctionVersions) {
-                $result['PersonFunctionVersions'] = $this->collPersonFunctionVersions->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
             }
         }
 
@@ -1296,15 +1054,6 @@ abstract class PersonFunction implements ActiveRecordInterface
             case 3:
                 $this->setUpdatedAt($value);
                 break;
-            case 4:
-                $this->setVersion($value);
-                break;
-            case 5:
-                $this->setVersionCreatedAt($value);
-                break;
-            case 6:
-                $this->setVersionCreatedBy($value);
-                break;
         } // switch()
     }
 
@@ -1333,9 +1082,6 @@ abstract class PersonFunction implements ActiveRecordInterface
         if (array_key_exists($keys[1], $arr)) $this->setCode($arr[$keys[1]]);
         if (array_key_exists($keys[2], $arr)) $this->setCreatedAt($arr[$keys[2]]);
         if (array_key_exists($keys[3], $arr)) $this->setUpdatedAt($arr[$keys[3]]);
-        if (array_key_exists($keys[4], $arr)) $this->setVersion($arr[$keys[4]]);
-        if (array_key_exists($keys[5], $arr)) $this->setVersionCreatedAt($arr[$keys[5]]);
-        if (array_key_exists($keys[6], $arr)) $this->setVersionCreatedBy($arr[$keys[6]]);
     }
 
     /**
@@ -1351,9 +1097,6 @@ abstract class PersonFunction implements ActiveRecordInterface
         if ($this->isColumnModified(PersonFunctionTableMap::CODE)) $criteria->add(PersonFunctionTableMap::CODE, $this->code);
         if ($this->isColumnModified(PersonFunctionTableMap::CREATED_AT)) $criteria->add(PersonFunctionTableMap::CREATED_AT, $this->created_at);
         if ($this->isColumnModified(PersonFunctionTableMap::UPDATED_AT)) $criteria->add(PersonFunctionTableMap::UPDATED_AT, $this->updated_at);
-        if ($this->isColumnModified(PersonFunctionTableMap::VERSION)) $criteria->add(PersonFunctionTableMap::VERSION, $this->version);
-        if ($this->isColumnModified(PersonFunctionTableMap::VERSION_CREATED_AT)) $criteria->add(PersonFunctionTableMap::VERSION_CREATED_AT, $this->version_created_at);
-        if ($this->isColumnModified(PersonFunctionTableMap::VERSION_CREATED_BY)) $criteria->add(PersonFunctionTableMap::VERSION_CREATED_BY, $this->version_created_by);
 
         return $criteria;
     }
@@ -1420,9 +1163,6 @@ abstract class PersonFunction implements ActiveRecordInterface
         $copyObj->setCode($this->getCode());
         $copyObj->setCreatedAt($this->getCreatedAt());
         $copyObj->setUpdatedAt($this->getUpdatedAt());
-        $copyObj->setVersion($this->getVersion());
-        $copyObj->setVersionCreatedAt($this->getVersionCreatedAt());
-        $copyObj->setVersionCreatedBy($this->getVersionCreatedBy());
 
         if ($deepCopy) {
             // important: temporarily setNew(false) because this affects the behavior of
@@ -1438,12 +1178,6 @@ abstract class PersonFunction implements ActiveRecordInterface
             foreach ($this->getPersonFunctionI18ns() as $relObj) {
                 if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
                     $copyObj->addPersonFunctionI18n($relObj->copy($deepCopy));
-                }
-            }
-
-            foreach ($this->getPersonFunctionVersions() as $relObj) {
-                if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
-                    $copyObj->addPersonFunctionVersion($relObj->copy($deepCopy));
                 }
             }
 
@@ -1493,9 +1227,6 @@ abstract class PersonFunction implements ActiveRecordInterface
         }
         if ('PersonFunctionI18n' == $relationName) {
             return $this->initPersonFunctionI18ns();
-        }
-        if ('PersonFunctionVersion' == $relationName) {
-            return $this->initPersonFunctionVersions();
         }
     }
 
@@ -1968,227 +1699,6 @@ abstract class PersonFunction implements ActiveRecordInterface
     }
 
     /**
-     * Clears out the collPersonFunctionVersions collection
-     *
-     * This does not modify the database; however, it will remove any associated objects, causing
-     * them to be refetched by subsequent calls to accessor method.
-     *
-     * @return void
-     * @see        addPersonFunctionVersions()
-     */
-    public function clearPersonFunctionVersions()
-    {
-        $this->collPersonFunctionVersions = null; // important to set this to NULL since that means it is uninitialized
-    }
-
-    /**
-     * Reset is the collPersonFunctionVersions collection loaded partially.
-     */
-    public function resetPartialPersonFunctionVersions($v = true)
-    {
-        $this->collPersonFunctionVersionsPartial = $v;
-    }
-
-    /**
-     * Initializes the collPersonFunctionVersions collection.
-     *
-     * By default this just sets the collPersonFunctionVersions collection to an empty array (like clearcollPersonFunctionVersions());
-     * however, you may wish to override this method in your stub class to provide setting appropriate
-     * to your application -- for example, setting the initial array to the values stored in database.
-     *
-     * @param      boolean $overrideExisting If set to true, the method call initializes
-     *                                        the collection even if it is not empty
-     *
-     * @return void
-     */
-    public function initPersonFunctionVersions($overrideExisting = true)
-    {
-        if (null !== $this->collPersonFunctionVersions && !$overrideExisting) {
-            return;
-        }
-        $this->collPersonFunctionVersions = new ObjectCollection();
-        $this->collPersonFunctionVersions->setModel('\Team\Model\PersonFunctionVersion');
-    }
-
-    /**
-     * Gets an array of ChildPersonFunctionVersion objects which contain a foreign key that references this object.
-     *
-     * If the $criteria is not null, it is used to always fetch the results from the database.
-     * Otherwise the results are fetched from the database the first time, then cached.
-     * Next time the same method is called without $criteria, the cached collection is returned.
-     * If this ChildPersonFunction is new, it will return
-     * an empty collection or the current collection; the criteria is ignored on a new object.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @return Collection|ChildPersonFunctionVersion[] List of ChildPersonFunctionVersion objects
-     * @throws PropelException
-     */
-    public function getPersonFunctionVersions($criteria = null, ConnectionInterface $con = null)
-    {
-        $partial = $this->collPersonFunctionVersionsPartial && !$this->isNew();
-        if (null === $this->collPersonFunctionVersions || null !== $criteria  || $partial) {
-            if ($this->isNew() && null === $this->collPersonFunctionVersions) {
-                // return empty collection
-                $this->initPersonFunctionVersions();
-            } else {
-                $collPersonFunctionVersions = ChildPersonFunctionVersionQuery::create(null, $criteria)
-                    ->filterByPersonFunction($this)
-                    ->find($con);
-
-                if (null !== $criteria) {
-                    if (false !== $this->collPersonFunctionVersionsPartial && count($collPersonFunctionVersions)) {
-                        $this->initPersonFunctionVersions(false);
-
-                        foreach ($collPersonFunctionVersions as $obj) {
-                            if (false == $this->collPersonFunctionVersions->contains($obj)) {
-                                $this->collPersonFunctionVersions->append($obj);
-                            }
-                        }
-
-                        $this->collPersonFunctionVersionsPartial = true;
-                    }
-
-                    reset($collPersonFunctionVersions);
-
-                    return $collPersonFunctionVersions;
-                }
-
-                if ($partial && $this->collPersonFunctionVersions) {
-                    foreach ($this->collPersonFunctionVersions as $obj) {
-                        if ($obj->isNew()) {
-                            $collPersonFunctionVersions[] = $obj;
-                        }
-                    }
-                }
-
-                $this->collPersonFunctionVersions = $collPersonFunctionVersions;
-                $this->collPersonFunctionVersionsPartial = false;
-            }
-        }
-
-        return $this->collPersonFunctionVersions;
-    }
-
-    /**
-     * Sets a collection of PersonFunctionVersion objects related by a one-to-many relationship
-     * to the current object.
-     * It will also schedule objects for deletion based on a diff between old objects (aka persisted)
-     * and new objects from the given Propel collection.
-     *
-     * @param      Collection $personFunctionVersions A Propel collection.
-     * @param      ConnectionInterface $con Optional connection object
-     * @return   ChildPersonFunction The current object (for fluent API support)
-     */
-    public function setPersonFunctionVersions(Collection $personFunctionVersions, ConnectionInterface $con = null)
-    {
-        $personFunctionVersionsToDelete = $this->getPersonFunctionVersions(new Criteria(), $con)->diff($personFunctionVersions);
-
-
-        //since at least one column in the foreign key is at the same time a PK
-        //we can not just set a PK to NULL in the lines below. We have to store
-        //a backup of all values, so we are able to manipulate these items based on the onDelete value later.
-        $this->personFunctionVersionsScheduledForDeletion = clone $personFunctionVersionsToDelete;
-
-        foreach ($personFunctionVersionsToDelete as $personFunctionVersionRemoved) {
-            $personFunctionVersionRemoved->setPersonFunction(null);
-        }
-
-        $this->collPersonFunctionVersions = null;
-        foreach ($personFunctionVersions as $personFunctionVersion) {
-            $this->addPersonFunctionVersion($personFunctionVersion);
-        }
-
-        $this->collPersonFunctionVersions = $personFunctionVersions;
-        $this->collPersonFunctionVersionsPartial = false;
-
-        return $this;
-    }
-
-    /**
-     * Returns the number of related PersonFunctionVersion objects.
-     *
-     * @param      Criteria $criteria
-     * @param      boolean $distinct
-     * @param      ConnectionInterface $con
-     * @return int             Count of related PersonFunctionVersion objects.
-     * @throws PropelException
-     */
-    public function countPersonFunctionVersions(Criteria $criteria = null, $distinct = false, ConnectionInterface $con = null)
-    {
-        $partial = $this->collPersonFunctionVersionsPartial && !$this->isNew();
-        if (null === $this->collPersonFunctionVersions || null !== $criteria || $partial) {
-            if ($this->isNew() && null === $this->collPersonFunctionVersions) {
-                return 0;
-            }
-
-            if ($partial && !$criteria) {
-                return count($this->getPersonFunctionVersions());
-            }
-
-            $query = ChildPersonFunctionVersionQuery::create(null, $criteria);
-            if ($distinct) {
-                $query->distinct();
-            }
-
-            return $query
-                ->filterByPersonFunction($this)
-                ->count($con);
-        }
-
-        return count($this->collPersonFunctionVersions);
-    }
-
-    /**
-     * Method called to associate a ChildPersonFunctionVersion object to this object
-     * through the ChildPersonFunctionVersion foreign key attribute.
-     *
-     * @param    ChildPersonFunctionVersion $l ChildPersonFunctionVersion
-     * @return   \Team\Model\PersonFunction The current object (for fluent API support)
-     */
-    public function addPersonFunctionVersion(ChildPersonFunctionVersion $l)
-    {
-        if ($this->collPersonFunctionVersions === null) {
-            $this->initPersonFunctionVersions();
-            $this->collPersonFunctionVersionsPartial = true;
-        }
-
-        if (!in_array($l, $this->collPersonFunctionVersions->getArrayCopy(), true)) { // only add it if the **same** object is not already associated
-            $this->doAddPersonFunctionVersion($l);
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param PersonFunctionVersion $personFunctionVersion The personFunctionVersion object to add.
-     */
-    protected function doAddPersonFunctionVersion($personFunctionVersion)
-    {
-        $this->collPersonFunctionVersions[]= $personFunctionVersion;
-        $personFunctionVersion->setPersonFunction($this);
-    }
-
-    /**
-     * @param  PersonFunctionVersion $personFunctionVersion The personFunctionVersion object to remove.
-     * @return ChildPersonFunction The current object (for fluent API support)
-     */
-    public function removePersonFunctionVersion($personFunctionVersion)
-    {
-        if ($this->getPersonFunctionVersions()->contains($personFunctionVersion)) {
-            $this->collPersonFunctionVersions->remove($this->collPersonFunctionVersions->search($personFunctionVersion));
-            if (null === $this->personFunctionVersionsScheduledForDeletion) {
-                $this->personFunctionVersionsScheduledForDeletion = clone $this->collPersonFunctionVersions;
-                $this->personFunctionVersionsScheduledForDeletion->clear();
-            }
-            $this->personFunctionVersionsScheduledForDeletion[]= clone $personFunctionVersion;
-            $personFunctionVersion->setPersonFunction(null);
-        }
-
-        return $this;
-    }
-
-    /**
      * Clears the current object and sets all attributes to their default values
      */
     public function clear()
@@ -2197,12 +1707,8 @@ abstract class PersonFunction implements ActiveRecordInterface
         $this->code = null;
         $this->created_at = null;
         $this->updated_at = null;
-        $this->version = null;
-        $this->version_created_at = null;
-        $this->version_created_by = null;
         $this->alreadyInSave = false;
         $this->clearAllReferences();
-        $this->applyDefaultValues();
         $this->resetModified();
         $this->setNew(true);
         $this->setDeleted(false);
@@ -2230,11 +1736,6 @@ abstract class PersonFunction implements ActiveRecordInterface
                     $o->clearAllReferences($deep);
                 }
             }
-            if ($this->collPersonFunctionVersions) {
-                foreach ($this->collPersonFunctionVersions as $o) {
-                    $o->clearAllReferences($deep);
-                }
-            }
         } // if ($deep)
 
         // i18n behavior
@@ -2243,7 +1744,6 @@ abstract class PersonFunction implements ActiveRecordInterface
 
         $this->collPersonFunctionLinks = null;
         $this->collPersonFunctionI18ns = null;
-        $this->collPersonFunctionVersions = null;
     }
 
     /**
@@ -2393,323 +1893,6 @@ abstract class PersonFunction implements ActiveRecordInterface
         return $this;
     }
 
-    // versionable behavior
-
-    /**
-     * Enforce a new Version of this object upon next save.
-     *
-     * @return \Team\Model\PersonFunction
-     */
-    public function enforceVersioning()
-    {
-        $this->enforceVersion = true;
-
-        return $this;
-    }
-
-    /**
-     * Checks whether the current state must be recorded as a version
-     *
-     * @return  boolean
-     */
-    public function isVersioningNecessary($con = null)
-    {
-        if ($this->alreadyInSave) {
-            return false;
-        }
-
-        if ($this->enforceVersion) {
-            return true;
-        }
-
-        if (ChildPersonFunctionQuery::isVersioningEnabled() && ($this->isNew() || $this->isModified()) || $this->isDeleted()) {
-            return true;
-        }
-        // to avoid infinite loops, emulate in save
-        $this->alreadyInSave = true;
-        foreach ($this->getPersonFunctionLinks(null, $con) as $relatedObject) {
-            if ($relatedObject->isVersioningNecessary($con)) {
-                $this->alreadyInSave = false;
-
-                return true;
-            }
-        }
-        $this->alreadyInSave = false;
-
-
-        return false;
-    }
-
-    /**
-     * Creates a version of the current object and saves it.
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ChildPersonFunctionVersion A version object
-     */
-    public function addVersion($con = null)
-    {
-        $this->enforceVersion = false;
-
-        $version = new ChildPersonFunctionVersion();
-        $version->setId($this->getId());
-        $version->setCode($this->getCode());
-        $version->setCreatedAt($this->getCreatedAt());
-        $version->setUpdatedAt($this->getUpdatedAt());
-        $version->setVersion($this->getVersion());
-        $version->setVersionCreatedAt($this->getVersionCreatedAt());
-        $version->setVersionCreatedBy($this->getVersionCreatedBy());
-        $version->setPersonFunction($this);
-        if ($relateds = $this->getPersonFunctionLinks($con)->toKeyValue('Id', 'Version')) {
-            $version->setPersonFunctionLinkIds(array_keys($relateds));
-            $version->setPersonFunctionLinkVersions(array_values($relateds));
-        }
-        $version->save($con);
-
-        return $version;
-    }
-
-    /**
-     * Sets the properties of the current object to the value they had at a specific version
-     *
-     * @param   integer $versionNumber The version number to read
-     * @param   ConnectionInterface $con The connection to use
-     *
-     * @return  ChildPersonFunction The current object (for fluent API support)
-     */
-    public function toVersion($versionNumber, $con = null)
-    {
-        $version = $this->getOneVersion($versionNumber, $con);
-        if (!$version) {
-            throw new PropelException(sprintf('No ChildPersonFunction object found with version %d', $version));
-        }
-        $this->populateFromVersion($version, $con);
-
-        return $this;
-    }
-
-    /**
-     * Sets the properties of the current object to the value they had at a specific version
-     *
-     * @param ChildPersonFunctionVersion $version The version object to use
-     * @param ConnectionInterface   $con the connection to use
-     * @param array                 $loadedObjects objects that been loaded in a chain of populateFromVersion calls on referrer or fk objects.
-     *
-     * @return ChildPersonFunction The current object (for fluent API support)
-     */
-    public function populateFromVersion($version, $con = null, &$loadedObjects = array())
-    {
-        $loadedObjects['ChildPersonFunction'][$version->getId()][$version->getVersion()] = $this;
-        $this->setId($version->getId());
-        $this->setCode($version->getCode());
-        $this->setCreatedAt($version->getCreatedAt());
-        $this->setUpdatedAt($version->getUpdatedAt());
-        $this->setVersion($version->getVersion());
-        $this->setVersionCreatedAt($version->getVersionCreatedAt());
-        $this->setVersionCreatedBy($version->getVersionCreatedBy());
-        if ($fkValues = $version->getPersonFunctionLinkIds()) {
-            $this->clearPersonFunctionLinks();
-            $fkVersions = $version->getPersonFunctionLinkVersions();
-            $query = ChildPersonFunctionLinkVersionQuery::create();
-            foreach ($fkValues as $key => $value) {
-                $c1 = $query->getNewCriterion(PersonFunctionLinkVersionTableMap::ID, $value);
-                $c2 = $query->getNewCriterion(PersonFunctionLinkVersionTableMap::VERSION, $fkVersions[$key]);
-                $c1->addAnd($c2);
-                $query->addOr($c1);
-            }
-            foreach ($query->find($con) as $relatedVersion) {
-                if (isset($loadedObjects['ChildPersonFunctionLink']) && isset($loadedObjects['ChildPersonFunctionLink'][$relatedVersion->getId()]) && isset($loadedObjects['ChildPersonFunctionLink'][$relatedVersion->getId()][$relatedVersion->getVersion()])) {
-                    $related = $loadedObjects['ChildPersonFunctionLink'][$relatedVersion->getId()][$relatedVersion->getVersion()];
-                } else {
-                    $related = new ChildPersonFunctionLink();
-                    $related->populateFromVersion($relatedVersion, $con, $loadedObjects);
-                    $related->setNew(false);
-                }
-                $this->addPersonFunctionLink($related);
-                $this->collPersonFunctionLinksPartial = false;
-            }
-        }
-
-        return $this;
-    }
-
-    /**
-     * Gets the latest persisted version number for the current object
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  integer
-     */
-    public function getLastVersionNumber($con = null)
-    {
-        $v = ChildPersonFunctionVersionQuery::create()
-            ->filterByPersonFunction($this)
-            ->orderByVersion('desc')
-            ->findOne($con);
-        if (!$v) {
-            return 0;
-        }
-
-        return $v->getVersion();
-    }
-
-    /**
-     * Checks whether the current object is the latest one
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  Boolean
-     */
-    public function isLastVersion($con = null)
-    {
-        return $this->getLastVersionNumber($con) == $this->getVersion();
-    }
-
-    /**
-     * Retrieves a version object for this entity and a version number
-     *
-     * @param   integer $versionNumber The version number to read
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ChildPersonFunctionVersion A version object
-     */
-    public function getOneVersion($versionNumber, $con = null)
-    {
-        return ChildPersonFunctionVersionQuery::create()
-            ->filterByPersonFunction($this)
-            ->filterByVersion($versionNumber)
-            ->findOne($con);
-    }
-
-    /**
-     * Gets all the versions of this object, in incremental order
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ObjectCollection A list of ChildPersonFunctionVersion objects
-     */
-    public function getAllVersions($con = null)
-    {
-        $criteria = new Criteria();
-        $criteria->addAscendingOrderByColumn(PersonFunctionVersionTableMap::VERSION);
-
-        return $this->getPersonFunctionVersions($criteria, $con);
-    }
-
-    /**
-     * Compares the current object with another of its version.
-     * <code>
-     * print_r($book->compareVersion(1));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   integer             $versionNumber
-     * @param   string              $keys Main key used for the result diff (versions|columns)
-     * @param   ConnectionInterface $con the connection to use
-     * @param   array               $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    public function compareVersion($versionNumber, $keys = 'columns', $con = null, $ignoredColumns = array())
-    {
-        $fromVersion = $this->toArray();
-        $toVersion = $this->getOneVersion($versionNumber, $con)->toArray();
-
-        return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
-    }
-
-    /**
-     * Compares two versions of the current object.
-     * <code>
-     * print_r($book->compareVersions(1, 2));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   integer             $fromVersionNumber
-     * @param   integer             $toVersionNumber
-     * @param   string              $keys Main key used for the result diff (versions|columns)
-     * @param   ConnectionInterface $con the connection to use
-     * @param   array               $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    public function compareVersions($fromVersionNumber, $toVersionNumber, $keys = 'columns', $con = null, $ignoredColumns = array())
-    {
-        $fromVersion = $this->getOneVersion($fromVersionNumber, $con)->toArray();
-        $toVersion = $this->getOneVersion($toVersionNumber, $con)->toArray();
-
-        return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
-    }
-
-    /**
-     * Computes the diff between two versions.
-     * <code>
-     * print_r($book->computeDiff(1, 2));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   array     $fromVersion     An array representing the original version.
-     * @param   array     $toVersion       An array representing the destination version.
-     * @param   string    $keys            Main key used for the result diff (versions|columns).
-     * @param   array     $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    protected function computeDiff($fromVersion, $toVersion, $keys = 'columns', $ignoredColumns = array())
-    {
-        $fromVersionNumber = $fromVersion['Version'];
-        $toVersionNumber = $toVersion['Version'];
-        $ignoredColumns = array_merge(array(
-            'Version',
-            'VersionCreatedAt',
-            'VersionCreatedBy',
-        ), $ignoredColumns);
-        $diff = array();
-        foreach ($fromVersion as $key => $value) {
-            if (in_array($key, $ignoredColumns)) {
-                continue;
-            }
-            if ($toVersion[$key] != $value) {
-                switch ($keys) {
-                    case 'versions':
-                        $diff[$fromVersionNumber][$key] = $value;
-                        $diff[$toVersionNumber][$key] = $toVersion[$key];
-                        break;
-                    default:
-                        $diff[$key] = array(
-                            $fromVersionNumber => $value,
-                            $toVersionNumber => $toVersion[$key],
-                        );
-                        break;
-                }
-            }
-        }
-
-        return $diff;
-    }
-    /**
-     * retrieve the last $number versions.
-     *
-     * @param Integer $number the number of record to return.
-     * @return PropelCollection|array \Team\Model\PersonFunctionVersion[] List of \Team\Model\PersonFunctionVersion objects
-     */
-    public function getLastVersions($number = 10, $criteria = null, $con = null)
-    {
-        $criteria = ChildPersonFunctionVersionQuery::create(null, $criteria);
-        $criteria->addDescendingOrderByColumn(PersonFunctionVersionTableMap::VERSION);
-        $criteria->limit($number);
-
-        return $this->getPersonFunctionVersions($criteria, $con);
-    }
     /**
      * Code to be run before persisting the object
      * @param  ConnectionInterface $con

--- a/Model/Base/PersonFunctionLink.php
+++ b/Model/Base/PersonFunctionLink.php
@@ -10,7 +10,6 @@ use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\Collection\Collection;
-use Propel\Runtime\Collection\ObjectCollection;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\BadMethodCallException;
 use Propel\Runtime\Exception\PropelException;
@@ -21,14 +20,9 @@ use Team\Model\Person as ChildPerson;
 use Team\Model\PersonFunction as ChildPersonFunction;
 use Team\Model\PersonFunctionLink as ChildPersonFunctionLink;
 use Team\Model\PersonFunctionLinkQuery as ChildPersonFunctionLinkQuery;
-use Team\Model\PersonFunctionLinkVersion as ChildPersonFunctionLinkVersion;
-use Team\Model\PersonFunctionLinkVersionQuery as ChildPersonFunctionLinkVersionQuery;
 use Team\Model\PersonFunctionQuery as ChildPersonFunctionQuery;
-use Team\Model\PersonFunctionVersionQuery as ChildPersonFunctionVersionQuery;
 use Team\Model\PersonQuery as ChildPersonQuery;
-use Team\Model\PersonVersionQuery as ChildPersonVersionQuery;
 use Team\Model\Map\PersonFunctionLinkTableMap;
-use Team\Model\Map\PersonFunctionLinkVersionTableMap;
 
 abstract class PersonFunctionLink implements ActiveRecordInterface
 {
@@ -95,25 +89,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
     protected $updated_at;
 
     /**
-     * The value for the version field.
-     * Note: this column has a database default value of: 0
-     * @var        int
-     */
-    protected $version;
-
-    /**
-     * The value for the version_created_at field.
-     * @var        string
-     */
-    protected $version_created_at;
-
-    /**
-     * The value for the version_created_by field.
-     * @var        string
-     */
-    protected $version_created_by;
-
-    /**
      * @var        Person
      */
     protected $aPerson;
@@ -124,12 +99,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
     protected $aPersonFunction;
 
     /**
-     * @var        ObjectCollection|ChildPersonFunctionLinkVersion[] Collection to store aggregation of ChildPersonFunctionLinkVersion objects.
-     */
-    protected $collPersonFunctionLinkVersions;
-    protected $collPersonFunctionLinkVersionsPartial;
-
-    /**
      * Flag to prevent endless save loop, if this object is referenced
      * by another object which falls in this transaction.
      *
@@ -137,38 +106,11 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
      */
     protected $alreadyInSave = false;
 
-    // versionable behavior
-
-
-    /**
-     * @var bool
-     */
-    protected $enforceVersion = false;
-
-    /**
-     * An array of objects scheduled for deletion.
-     * @var ObjectCollection
-     */
-    protected $personFunctionLinkVersionsScheduledForDeletion = null;
-
-    /**
-     * Applies default values to this object.
-     * This method should be called from the object's constructor (or
-     * equivalent initialization method).
-     * @see __construct()
-     */
-    public function applyDefaultValues()
-    {
-        $this->version = 0;
-    }
-
     /**
      * Initializes internal state of Team\Model\Base\PersonFunctionLink object.
-     * @see applyDefaults()
      */
     public function __construct()
     {
-        $this->applyDefaultValues();
     }
 
     /**
@@ -496,48 +438,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
     }
 
     /**
-     * Get the [version] column value.
-     *
-     * @return   int
-     */
-    public function getVersion()
-    {
-
-        return $this->version;
-    }
-
-    /**
-     * Get the [optionally formatted] temporal [version_created_at] column value.
-     *
-     *
-     * @param      string $format The date/time format string (either date()-style or strftime()-style).
-     *                            If format is NULL, then the raw \DateTime object will be returned.
-     *
-     * @return mixed Formatted date/time value as string or \DateTime object (if format is NULL), NULL if column is NULL, and 0 if column value is 0000-00-00 00:00:00
-     *
-     * @throws PropelException - if unable to parse/validate the date/time value.
-     */
-    public function getVersionCreatedAt($format = NULL)
-    {
-        if ($format === null) {
-            return $this->version_created_at;
-        } else {
-            return $this->version_created_at instanceof \DateTime ? $this->version_created_at->format($format) : null;
-        }
-    }
-
-    /**
-     * Get the [version_created_by] column value.
-     *
-     * @return   string
-     */
-    public function getVersionCreatedBy()
-    {
-
-        return $this->version_created_by;
-    }
-
-    /**
      * Set the value of [id] column.
      *
      * @param      int $v new value
@@ -651,69 +551,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
     } // setUpdatedAt()
 
     /**
-     * Set the value of [version] column.
-     *
-     * @param      int $v new value
-     * @return   \Team\Model\PersonFunctionLink The current object (for fluent API support)
-     */
-    public function setVersion($v)
-    {
-        if ($v !== null) {
-            $v = (int) $v;
-        }
-
-        if ($this->version !== $v) {
-            $this->version = $v;
-            $this->modifiedColumns[PersonFunctionLinkTableMap::VERSION] = true;
-        }
-
-
-        return $this;
-    } // setVersion()
-
-    /**
-     * Sets the value of [version_created_at] column to a normalized version of the date/time value specified.
-     *
-     * @param      mixed $v string, integer (timestamp), or \DateTime value.
-     *               Empty strings are treated as NULL.
-     * @return   \Team\Model\PersonFunctionLink The current object (for fluent API support)
-     */
-    public function setVersionCreatedAt($v)
-    {
-        $dt = PropelDateTime::newInstance($v, null, '\DateTime');
-        if ($this->version_created_at !== null || $dt !== null) {
-            if ($dt !== $this->version_created_at) {
-                $this->version_created_at = $dt;
-                $this->modifiedColumns[PersonFunctionLinkTableMap::VERSION_CREATED_AT] = true;
-            }
-        } // if either are not null
-
-
-        return $this;
-    } // setVersionCreatedAt()
-
-    /**
-     * Set the value of [version_created_by] column.
-     *
-     * @param      string $v new value
-     * @return   \Team\Model\PersonFunctionLink The current object (for fluent API support)
-     */
-    public function setVersionCreatedBy($v)
-    {
-        if ($v !== null) {
-            $v = (string) $v;
-        }
-
-        if ($this->version_created_by !== $v) {
-            $this->version_created_by = $v;
-            $this->modifiedColumns[PersonFunctionLinkTableMap::VERSION_CREATED_BY] = true;
-        }
-
-
-        return $this;
-    } // setVersionCreatedBy()
-
-    /**
      * Indicates whether the columns in this object are only set to default values.
      *
      * This method can be used in conjunction with isModified() to indicate whether an object is both
@@ -723,10 +560,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
      */
     public function hasOnlyDefaultValues()
     {
-            if ($this->version !== 0) {
-                return false;
-            }
-
         // otherwise, everything was equal, so return TRUE
         return true;
     } // hasOnlyDefaultValues()
@@ -774,18 +607,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
                 $col = null;
             }
             $this->updated_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : PersonFunctionLinkTableMap::translateFieldName('Version', TableMap::TYPE_PHPNAME, $indexType)];
-            $this->version = (null !== $col) ? (int) $col : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : PersonFunctionLinkTableMap::translateFieldName('VersionCreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
-            if ($col === '0000-00-00 00:00:00') {
-                $col = null;
-            }
-            $this->version_created_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : PersonFunctionLinkTableMap::translateFieldName('VersionCreatedBy', TableMap::TYPE_PHPNAME, $indexType)];
-            $this->version_created_by = (null !== $col) ? (string) $col : null;
             $this->resetModified();
 
             $this->setNew(false);
@@ -794,7 +615,7 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 8; // 8 = PersonFunctionLinkTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 5; // 5 = PersonFunctionLinkTableMap::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception $e) {
             throw new PropelException("Error populating \Team\Model\PersonFunctionLink object", 0, $e);
@@ -863,8 +684,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
 
             $this->aPerson = null;
             $this->aPersonFunction = null;
-            $this->collPersonFunctionLinkVersions = null;
-
         } // if (deep)
     }
 
@@ -933,14 +752,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
         $isInsert = $this->isNew();
         try {
             $ret = $this->preSave($con);
-            // versionable behavior
-            if ($this->isVersioningNecessary()) {
-                $this->setVersion($this->isNew() ? 1 : $this->getLastVersionNumber($con) + 1);
-                if (!$this->isColumnModified(PersonFunctionLinkTableMap::VERSION_CREATED_AT)) {
-                    $this->setVersionCreatedAt(time());
-                }
-                $createVersion = true; // for postSave hook
-            }
             if ($isInsert) {
                 $ret = $ret && $this->preInsert($con);
                 // timestampable behavior
@@ -965,10 +776,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
                     $this->postUpdate($con);
                 }
                 $this->postSave($con);
-                // versionable behavior
-                if (isset($createVersion)) {
-                    $this->addVersion($con);
-                }
                 PersonFunctionLinkTableMap::addInstanceToPool($this);
             } else {
                 $affectedRows = 0;
@@ -1029,23 +836,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
                 $this->resetModified();
             }
 
-            if ($this->personFunctionLinkVersionsScheduledForDeletion !== null) {
-                if (!$this->personFunctionLinkVersionsScheduledForDeletion->isEmpty()) {
-                    \Team\Model\PersonFunctionLinkVersionQuery::create()
-                        ->filterByPrimaryKeys($this->personFunctionLinkVersionsScheduledForDeletion->getPrimaryKeys(false))
-                        ->delete($con);
-                    $this->personFunctionLinkVersionsScheduledForDeletion = null;
-                }
-            }
-
-                if ($this->collPersonFunctionLinkVersions !== null) {
-            foreach ($this->collPersonFunctionLinkVersions as $referrerFK) {
-                    if (!$referrerFK->isDeleted() && ($referrerFK->isNew() || $referrerFK->isModified())) {
-                        $affectedRows += $referrerFK->save($con);
-                    }
-                }
-            }
-
             $this->alreadyInSave = false;
 
         }
@@ -1087,15 +877,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
         if ($this->isColumnModified(PersonFunctionLinkTableMap::UPDATED_AT)) {
             $modifiedColumns[':p' . $index++]  = 'UPDATED_AT';
         }
-        if ($this->isColumnModified(PersonFunctionLinkTableMap::VERSION)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION';
-        }
-        if ($this->isColumnModified(PersonFunctionLinkTableMap::VERSION_CREATED_AT)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION_CREATED_AT';
-        }
-        if ($this->isColumnModified(PersonFunctionLinkTableMap::VERSION_CREATED_BY)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION_CREATED_BY';
-        }
 
         $sql = sprintf(
             'INSERT INTO person_function_link (%s) VALUES (%s)',
@@ -1121,15 +902,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
                         break;
                     case 'UPDATED_AT':
                         $stmt->bindValue($identifier, $this->updated_at ? $this->updated_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
-                        break;
-                    case 'VERSION':
-                        $stmt->bindValue($identifier, $this->version, PDO::PARAM_INT);
-                        break;
-                    case 'VERSION_CREATED_AT':
-                        $stmt->bindValue($identifier, $this->version_created_at ? $this->version_created_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
-                        break;
-                    case 'VERSION_CREATED_BY':
-                        $stmt->bindValue($identifier, $this->version_created_by, PDO::PARAM_STR);
                         break;
                 }
             }
@@ -1208,15 +980,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
             case 4:
                 return $this->getUpdatedAt();
                 break;
-            case 5:
-                return $this->getVersion();
-                break;
-            case 6:
-                return $this->getVersionCreatedAt();
-                break;
-            case 7:
-                return $this->getVersionCreatedBy();
-                break;
             default:
                 return null;
                 break;
@@ -1251,9 +1014,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
             $keys[2] => $this->getFunctionId(),
             $keys[3] => $this->getCreatedAt(),
             $keys[4] => $this->getUpdatedAt(),
-            $keys[5] => $this->getVersion(),
-            $keys[6] => $this->getVersionCreatedAt(),
-            $keys[7] => $this->getVersionCreatedBy(),
         );
         $virtualColumns = $this->virtualColumns;
         foreach ($virtualColumns as $key => $virtualColumn) {
@@ -1266,9 +1026,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
             }
             if (null !== $this->aPersonFunction) {
                 $result['PersonFunction'] = $this->aPersonFunction->toArray($keyType, $includeLazyLoadColumns,  $alreadyDumpedObjects, true);
-            }
-            if (null !== $this->collPersonFunctionLinkVersions) {
-                $result['PersonFunctionLinkVersions'] = $this->collPersonFunctionLinkVersions->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
             }
         }
 
@@ -1319,15 +1076,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
             case 4:
                 $this->setUpdatedAt($value);
                 break;
-            case 5:
-                $this->setVersion($value);
-                break;
-            case 6:
-                $this->setVersionCreatedAt($value);
-                break;
-            case 7:
-                $this->setVersionCreatedBy($value);
-                break;
         } // switch()
     }
 
@@ -1357,9 +1105,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
         if (array_key_exists($keys[2], $arr)) $this->setFunctionId($arr[$keys[2]]);
         if (array_key_exists($keys[3], $arr)) $this->setCreatedAt($arr[$keys[3]]);
         if (array_key_exists($keys[4], $arr)) $this->setUpdatedAt($arr[$keys[4]]);
-        if (array_key_exists($keys[5], $arr)) $this->setVersion($arr[$keys[5]]);
-        if (array_key_exists($keys[6], $arr)) $this->setVersionCreatedAt($arr[$keys[6]]);
-        if (array_key_exists($keys[7], $arr)) $this->setVersionCreatedBy($arr[$keys[7]]);
     }
 
     /**
@@ -1376,9 +1121,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
         if ($this->isColumnModified(PersonFunctionLinkTableMap::FUNCTION_ID)) $criteria->add(PersonFunctionLinkTableMap::FUNCTION_ID, $this->function_id);
         if ($this->isColumnModified(PersonFunctionLinkTableMap::CREATED_AT)) $criteria->add(PersonFunctionLinkTableMap::CREATED_AT, $this->created_at);
         if ($this->isColumnModified(PersonFunctionLinkTableMap::UPDATED_AT)) $criteria->add(PersonFunctionLinkTableMap::UPDATED_AT, $this->updated_at);
-        if ($this->isColumnModified(PersonFunctionLinkTableMap::VERSION)) $criteria->add(PersonFunctionLinkTableMap::VERSION, $this->version);
-        if ($this->isColumnModified(PersonFunctionLinkTableMap::VERSION_CREATED_AT)) $criteria->add(PersonFunctionLinkTableMap::VERSION_CREATED_AT, $this->version_created_at);
-        if ($this->isColumnModified(PersonFunctionLinkTableMap::VERSION_CREATED_BY)) $criteria->add(PersonFunctionLinkTableMap::VERSION_CREATED_BY, $this->version_created_by);
 
         return $criteria;
     }
@@ -1446,23 +1188,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
         $copyObj->setFunctionId($this->getFunctionId());
         $copyObj->setCreatedAt($this->getCreatedAt());
         $copyObj->setUpdatedAt($this->getUpdatedAt());
-        $copyObj->setVersion($this->getVersion());
-        $copyObj->setVersionCreatedAt($this->getVersionCreatedAt());
-        $copyObj->setVersionCreatedBy($this->getVersionCreatedBy());
-
-        if ($deepCopy) {
-            // important: temporarily setNew(false) because this affects the behavior of
-            // the getter/setter methods for fkey referrer objects.
-            $copyObj->setNew(false);
-
-            foreach ($this->getPersonFunctionLinkVersions() as $relObj) {
-                if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
-                    $copyObj->addPersonFunctionLinkVersion($relObj->copy($deepCopy));
-                }
-            }
-
-        } // if ($deepCopy)
-
         if ($makeNew) {
             $copyObj->setNew(true);
             $copyObj->setId(NULL); // this is a auto-increment column, so set to default value
@@ -1593,243 +1318,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
         return $this->aPersonFunction;
     }
 
-
-    /**
-     * Initializes a collection based on the name of a relation.
-     * Avoids crafting an 'init[$relationName]s' method name
-     * that wouldn't work when StandardEnglishPluralizer is used.
-     *
-     * @param      string $relationName The name of the relation to initialize
-     * @return void
-     */
-    public function initRelation($relationName)
-    {
-        if ('PersonFunctionLinkVersion' == $relationName) {
-            return $this->initPersonFunctionLinkVersions();
-        }
-    }
-
-    /**
-     * Clears out the collPersonFunctionLinkVersions collection
-     *
-     * This does not modify the database; however, it will remove any associated objects, causing
-     * them to be refetched by subsequent calls to accessor method.
-     *
-     * @return void
-     * @see        addPersonFunctionLinkVersions()
-     */
-    public function clearPersonFunctionLinkVersions()
-    {
-        $this->collPersonFunctionLinkVersions = null; // important to set this to NULL since that means it is uninitialized
-    }
-
-    /**
-     * Reset is the collPersonFunctionLinkVersions collection loaded partially.
-     */
-    public function resetPartialPersonFunctionLinkVersions($v = true)
-    {
-        $this->collPersonFunctionLinkVersionsPartial = $v;
-    }
-
-    /**
-     * Initializes the collPersonFunctionLinkVersions collection.
-     *
-     * By default this just sets the collPersonFunctionLinkVersions collection to an empty array (like clearcollPersonFunctionLinkVersions());
-     * however, you may wish to override this method in your stub class to provide setting appropriate
-     * to your application -- for example, setting the initial array to the values stored in database.
-     *
-     * @param      boolean $overrideExisting If set to true, the method call initializes
-     *                                        the collection even if it is not empty
-     *
-     * @return void
-     */
-    public function initPersonFunctionLinkVersions($overrideExisting = true)
-    {
-        if (null !== $this->collPersonFunctionLinkVersions && !$overrideExisting) {
-            return;
-        }
-        $this->collPersonFunctionLinkVersions = new ObjectCollection();
-        $this->collPersonFunctionLinkVersions->setModel('\Team\Model\PersonFunctionLinkVersion');
-    }
-
-    /**
-     * Gets an array of ChildPersonFunctionLinkVersion objects which contain a foreign key that references this object.
-     *
-     * If the $criteria is not null, it is used to always fetch the results from the database.
-     * Otherwise the results are fetched from the database the first time, then cached.
-     * Next time the same method is called without $criteria, the cached collection is returned.
-     * If this ChildPersonFunctionLink is new, it will return
-     * an empty collection or the current collection; the criteria is ignored on a new object.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @return Collection|ChildPersonFunctionLinkVersion[] List of ChildPersonFunctionLinkVersion objects
-     * @throws PropelException
-     */
-    public function getPersonFunctionLinkVersions($criteria = null, ConnectionInterface $con = null)
-    {
-        $partial = $this->collPersonFunctionLinkVersionsPartial && !$this->isNew();
-        if (null === $this->collPersonFunctionLinkVersions || null !== $criteria  || $partial) {
-            if ($this->isNew() && null === $this->collPersonFunctionLinkVersions) {
-                // return empty collection
-                $this->initPersonFunctionLinkVersions();
-            } else {
-                $collPersonFunctionLinkVersions = ChildPersonFunctionLinkVersionQuery::create(null, $criteria)
-                    ->filterByPersonFunctionLink($this)
-                    ->find($con);
-
-                if (null !== $criteria) {
-                    if (false !== $this->collPersonFunctionLinkVersionsPartial && count($collPersonFunctionLinkVersions)) {
-                        $this->initPersonFunctionLinkVersions(false);
-
-                        foreach ($collPersonFunctionLinkVersions as $obj) {
-                            if (false == $this->collPersonFunctionLinkVersions->contains($obj)) {
-                                $this->collPersonFunctionLinkVersions->append($obj);
-                            }
-                        }
-
-                        $this->collPersonFunctionLinkVersionsPartial = true;
-                    }
-
-                    reset($collPersonFunctionLinkVersions);
-
-                    return $collPersonFunctionLinkVersions;
-                }
-
-                if ($partial && $this->collPersonFunctionLinkVersions) {
-                    foreach ($this->collPersonFunctionLinkVersions as $obj) {
-                        if ($obj->isNew()) {
-                            $collPersonFunctionLinkVersions[] = $obj;
-                        }
-                    }
-                }
-
-                $this->collPersonFunctionLinkVersions = $collPersonFunctionLinkVersions;
-                $this->collPersonFunctionLinkVersionsPartial = false;
-            }
-        }
-
-        return $this->collPersonFunctionLinkVersions;
-    }
-
-    /**
-     * Sets a collection of PersonFunctionLinkVersion objects related by a one-to-many relationship
-     * to the current object.
-     * It will also schedule objects for deletion based on a diff between old objects (aka persisted)
-     * and new objects from the given Propel collection.
-     *
-     * @param      Collection $personFunctionLinkVersions A Propel collection.
-     * @param      ConnectionInterface $con Optional connection object
-     * @return   ChildPersonFunctionLink The current object (for fluent API support)
-     */
-    public function setPersonFunctionLinkVersions(Collection $personFunctionLinkVersions, ConnectionInterface $con = null)
-    {
-        $personFunctionLinkVersionsToDelete = $this->getPersonFunctionLinkVersions(new Criteria(), $con)->diff($personFunctionLinkVersions);
-
-
-        //since at least one column in the foreign key is at the same time a PK
-        //we can not just set a PK to NULL in the lines below. We have to store
-        //a backup of all values, so we are able to manipulate these items based on the onDelete value later.
-        $this->personFunctionLinkVersionsScheduledForDeletion = clone $personFunctionLinkVersionsToDelete;
-
-        foreach ($personFunctionLinkVersionsToDelete as $personFunctionLinkVersionRemoved) {
-            $personFunctionLinkVersionRemoved->setPersonFunctionLink(null);
-        }
-
-        $this->collPersonFunctionLinkVersions = null;
-        foreach ($personFunctionLinkVersions as $personFunctionLinkVersion) {
-            $this->addPersonFunctionLinkVersion($personFunctionLinkVersion);
-        }
-
-        $this->collPersonFunctionLinkVersions = $personFunctionLinkVersions;
-        $this->collPersonFunctionLinkVersionsPartial = false;
-
-        return $this;
-    }
-
-    /**
-     * Returns the number of related PersonFunctionLinkVersion objects.
-     *
-     * @param      Criteria $criteria
-     * @param      boolean $distinct
-     * @param      ConnectionInterface $con
-     * @return int             Count of related PersonFunctionLinkVersion objects.
-     * @throws PropelException
-     */
-    public function countPersonFunctionLinkVersions(Criteria $criteria = null, $distinct = false, ConnectionInterface $con = null)
-    {
-        $partial = $this->collPersonFunctionLinkVersionsPartial && !$this->isNew();
-        if (null === $this->collPersonFunctionLinkVersions || null !== $criteria || $partial) {
-            if ($this->isNew() && null === $this->collPersonFunctionLinkVersions) {
-                return 0;
-            }
-
-            if ($partial && !$criteria) {
-                return count($this->getPersonFunctionLinkVersions());
-            }
-
-            $query = ChildPersonFunctionLinkVersionQuery::create(null, $criteria);
-            if ($distinct) {
-                $query->distinct();
-            }
-
-            return $query
-                ->filterByPersonFunctionLink($this)
-                ->count($con);
-        }
-
-        return count($this->collPersonFunctionLinkVersions);
-    }
-
-    /**
-     * Method called to associate a ChildPersonFunctionLinkVersion object to this object
-     * through the ChildPersonFunctionLinkVersion foreign key attribute.
-     *
-     * @param    ChildPersonFunctionLinkVersion $l ChildPersonFunctionLinkVersion
-     * @return   \Team\Model\PersonFunctionLink The current object (for fluent API support)
-     */
-    public function addPersonFunctionLinkVersion(ChildPersonFunctionLinkVersion $l)
-    {
-        if ($this->collPersonFunctionLinkVersions === null) {
-            $this->initPersonFunctionLinkVersions();
-            $this->collPersonFunctionLinkVersionsPartial = true;
-        }
-
-        if (!in_array($l, $this->collPersonFunctionLinkVersions->getArrayCopy(), true)) { // only add it if the **same** object is not already associated
-            $this->doAddPersonFunctionLinkVersion($l);
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param PersonFunctionLinkVersion $personFunctionLinkVersion The personFunctionLinkVersion object to add.
-     */
-    protected function doAddPersonFunctionLinkVersion($personFunctionLinkVersion)
-    {
-        $this->collPersonFunctionLinkVersions[]= $personFunctionLinkVersion;
-        $personFunctionLinkVersion->setPersonFunctionLink($this);
-    }
-
-    /**
-     * @param  PersonFunctionLinkVersion $personFunctionLinkVersion The personFunctionLinkVersion object to remove.
-     * @return ChildPersonFunctionLink The current object (for fluent API support)
-     */
-    public function removePersonFunctionLinkVersion($personFunctionLinkVersion)
-    {
-        if ($this->getPersonFunctionLinkVersions()->contains($personFunctionLinkVersion)) {
-            $this->collPersonFunctionLinkVersions->remove($this->collPersonFunctionLinkVersions->search($personFunctionLinkVersion));
-            if (null === $this->personFunctionLinkVersionsScheduledForDeletion) {
-                $this->personFunctionLinkVersionsScheduledForDeletion = clone $this->collPersonFunctionLinkVersions;
-                $this->personFunctionLinkVersionsScheduledForDeletion->clear();
-            }
-            $this->personFunctionLinkVersionsScheduledForDeletion[]= clone $personFunctionLinkVersion;
-            $personFunctionLinkVersion->setPersonFunctionLink(null);
-        }
-
-        return $this;
-    }
-
     /**
      * Clears the current object and sets all attributes to their default values
      */
@@ -1840,12 +1328,8 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
         $this->function_id = null;
         $this->created_at = null;
         $this->updated_at = null;
-        $this->version = null;
-        $this->version_created_at = null;
-        $this->version_created_by = null;
         $this->alreadyInSave = false;
         $this->clearAllReferences();
-        $this->applyDefaultValues();
         $this->resetModified();
         $this->setNew(true);
         $this->setDeleted(false);
@@ -1863,14 +1347,8 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
     public function clearAllReferences($deep = false)
     {
         if ($deep) {
-            if ($this->collPersonFunctionLinkVersions) {
-                foreach ($this->collPersonFunctionLinkVersions as $o) {
-                    $o->clearAllReferences($deep);
-                }
-            }
         } // if ($deep)
 
-        $this->collPersonFunctionLinkVersions = null;
         $this->aPerson = null;
         $this->aPersonFunction = null;
     }
@@ -1899,330 +1377,6 @@ abstract class PersonFunctionLink implements ActiveRecordInterface
         return $this;
     }
 
-    // versionable behavior
-
-    /**
-     * Enforce a new Version of this object upon next save.
-     *
-     * @return \Team\Model\PersonFunctionLink
-     */
-    public function enforceVersioning()
-    {
-        $this->enforceVersion = true;
-
-        return $this;
-    }
-
-    /**
-     * Checks whether the current state must be recorded as a version
-     *
-     * @return  boolean
-     */
-    public function isVersioningNecessary($con = null)
-    {
-        if ($this->alreadyInSave) {
-            return false;
-        }
-
-        if ($this->enforceVersion) {
-            return true;
-        }
-
-        if (ChildPersonFunctionLinkQuery::isVersioningEnabled() && ($this->isNew() || $this->isModified()) || $this->isDeleted()) {
-            return true;
-        }
-        if (null !== ($object = $this->getPerson($con)) && $object->isVersioningNecessary($con)) {
-            return true;
-        }
-
-        if (null !== ($object = $this->getPersonFunction($con)) && $object->isVersioningNecessary($con)) {
-            return true;
-        }
-
-
-        return false;
-    }
-
-    /**
-     * Creates a version of the current object and saves it.
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ChildPersonFunctionLinkVersion A version object
-     */
-    public function addVersion($con = null)
-    {
-        $this->enforceVersion = false;
-
-        $version = new ChildPersonFunctionLinkVersion();
-        $version->setId($this->getId());
-        $version->setPersonId($this->getPersonId());
-        $version->setFunctionId($this->getFunctionId());
-        $version->setCreatedAt($this->getCreatedAt());
-        $version->setUpdatedAt($this->getUpdatedAt());
-        $version->setVersion($this->getVersion());
-        $version->setVersionCreatedAt($this->getVersionCreatedAt());
-        $version->setVersionCreatedBy($this->getVersionCreatedBy());
-        $version->setPersonFunctionLink($this);
-        if (($related = $this->getPerson($con)) && $related->getVersion()) {
-            $version->setPersonIdVersion($related->getVersion());
-        }
-        if (($related = $this->getPersonFunction($con)) && $related->getVersion()) {
-            $version->setFunctionIdVersion($related->getVersion());
-        }
-        $version->save($con);
-
-        return $version;
-    }
-
-    /**
-     * Sets the properties of the current object to the value they had at a specific version
-     *
-     * @param   integer $versionNumber The version number to read
-     * @param   ConnectionInterface $con The connection to use
-     *
-     * @return  ChildPersonFunctionLink The current object (for fluent API support)
-     */
-    public function toVersion($versionNumber, $con = null)
-    {
-        $version = $this->getOneVersion($versionNumber, $con);
-        if (!$version) {
-            throw new PropelException(sprintf('No ChildPersonFunctionLink object found with version %d', $version));
-        }
-        $this->populateFromVersion($version, $con);
-
-        return $this;
-    }
-
-    /**
-     * Sets the properties of the current object to the value they had at a specific version
-     *
-     * @param ChildPersonFunctionLinkVersion $version The version object to use
-     * @param ConnectionInterface   $con the connection to use
-     * @param array                 $loadedObjects objects that been loaded in a chain of populateFromVersion calls on referrer or fk objects.
-     *
-     * @return ChildPersonFunctionLink The current object (for fluent API support)
-     */
-    public function populateFromVersion($version, $con = null, &$loadedObjects = array())
-    {
-        $loadedObjects['ChildPersonFunctionLink'][$version->getId()][$version->getVersion()] = $this;
-        $this->setId($version->getId());
-        $this->setPersonId($version->getPersonId());
-        $this->setFunctionId($version->getFunctionId());
-        $this->setCreatedAt($version->getCreatedAt());
-        $this->setUpdatedAt($version->getUpdatedAt());
-        $this->setVersion($version->getVersion());
-        $this->setVersionCreatedAt($version->getVersionCreatedAt());
-        $this->setVersionCreatedBy($version->getVersionCreatedBy());
-        if ($fkValue = $version->getPersonId()) {
-            if (isset($loadedObjects['ChildPerson']) && isset($loadedObjects['ChildPerson'][$fkValue]) && isset($loadedObjects['ChildPerson'][$fkValue][$version->getPersonIdVersion()])) {
-                $related = $loadedObjects['ChildPerson'][$fkValue][$version->getPersonIdVersion()];
-            } else {
-                $related = new ChildPerson();
-                $relatedVersion = ChildPersonVersionQuery::create()
-                    ->filterById($fkValue)
-                    ->filterByVersion($version->getPersonIdVersion())
-                    ->findOne($con);
-                $related->populateFromVersion($relatedVersion, $con, $loadedObjects);
-                $related->setNew(false);
-            }
-            $this->setPerson($related);
-        }
-        if ($fkValue = $version->getFunctionId()) {
-            if (isset($loadedObjects['ChildPersonFunction']) && isset($loadedObjects['ChildPersonFunction'][$fkValue]) && isset($loadedObjects['ChildPersonFunction'][$fkValue][$version->getFunctionIdVersion()])) {
-                $related = $loadedObjects['ChildPersonFunction'][$fkValue][$version->getFunctionIdVersion()];
-            } else {
-                $related = new ChildPersonFunction();
-                $relatedVersion = ChildPersonFunctionVersionQuery::create()
-                    ->filterById($fkValue)
-                    ->filterByVersion($version->getFunctionIdVersion())
-                    ->findOne($con);
-                $related->populateFromVersion($relatedVersion, $con, $loadedObjects);
-                $related->setNew(false);
-            }
-            $this->setPersonFunction($related);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Gets the latest persisted version number for the current object
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  integer
-     */
-    public function getLastVersionNumber($con = null)
-    {
-        $v = ChildPersonFunctionLinkVersionQuery::create()
-            ->filterByPersonFunctionLink($this)
-            ->orderByVersion('desc')
-            ->findOne($con);
-        if (!$v) {
-            return 0;
-        }
-
-        return $v->getVersion();
-    }
-
-    /**
-     * Checks whether the current object is the latest one
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  Boolean
-     */
-    public function isLastVersion($con = null)
-    {
-        return $this->getLastVersionNumber($con) == $this->getVersion();
-    }
-
-    /**
-     * Retrieves a version object for this entity and a version number
-     *
-     * @param   integer $versionNumber The version number to read
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ChildPersonFunctionLinkVersion A version object
-     */
-    public function getOneVersion($versionNumber, $con = null)
-    {
-        return ChildPersonFunctionLinkVersionQuery::create()
-            ->filterByPersonFunctionLink($this)
-            ->filterByVersion($versionNumber)
-            ->findOne($con);
-    }
-
-    /**
-     * Gets all the versions of this object, in incremental order
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ObjectCollection A list of ChildPersonFunctionLinkVersion objects
-     */
-    public function getAllVersions($con = null)
-    {
-        $criteria = new Criteria();
-        $criteria->addAscendingOrderByColumn(PersonFunctionLinkVersionTableMap::VERSION);
-
-        return $this->getPersonFunctionLinkVersions($criteria, $con);
-    }
-
-    /**
-     * Compares the current object with another of its version.
-     * <code>
-     * print_r($book->compareVersion(1));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   integer             $versionNumber
-     * @param   string              $keys Main key used for the result diff (versions|columns)
-     * @param   ConnectionInterface $con the connection to use
-     * @param   array               $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    public function compareVersion($versionNumber, $keys = 'columns', $con = null, $ignoredColumns = array())
-    {
-        $fromVersion = $this->toArray();
-        $toVersion = $this->getOneVersion($versionNumber, $con)->toArray();
-
-        return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
-    }
-
-    /**
-     * Compares two versions of the current object.
-     * <code>
-     * print_r($book->compareVersions(1, 2));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   integer             $fromVersionNumber
-     * @param   integer             $toVersionNumber
-     * @param   string              $keys Main key used for the result diff (versions|columns)
-     * @param   ConnectionInterface $con the connection to use
-     * @param   array               $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    public function compareVersions($fromVersionNumber, $toVersionNumber, $keys = 'columns', $con = null, $ignoredColumns = array())
-    {
-        $fromVersion = $this->getOneVersion($fromVersionNumber, $con)->toArray();
-        $toVersion = $this->getOneVersion($toVersionNumber, $con)->toArray();
-
-        return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
-    }
-
-    /**
-     * Computes the diff between two versions.
-     * <code>
-     * print_r($book->computeDiff(1, 2));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   array     $fromVersion     An array representing the original version.
-     * @param   array     $toVersion       An array representing the destination version.
-     * @param   string    $keys            Main key used for the result diff (versions|columns).
-     * @param   array     $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    protected function computeDiff($fromVersion, $toVersion, $keys = 'columns', $ignoredColumns = array())
-    {
-        $fromVersionNumber = $fromVersion['Version'];
-        $toVersionNumber = $toVersion['Version'];
-        $ignoredColumns = array_merge(array(
-            'Version',
-            'VersionCreatedAt',
-            'VersionCreatedBy',
-        ), $ignoredColumns);
-        $diff = array();
-        foreach ($fromVersion as $key => $value) {
-            if (in_array($key, $ignoredColumns)) {
-                continue;
-            }
-            if ($toVersion[$key] != $value) {
-                switch ($keys) {
-                    case 'versions':
-                        $diff[$fromVersionNumber][$key] = $value;
-                        $diff[$toVersionNumber][$key] = $toVersion[$key];
-                        break;
-                    default:
-                        $diff[$key] = array(
-                            $fromVersionNumber => $value,
-                            $toVersionNumber => $toVersion[$key],
-                        );
-                        break;
-                }
-            }
-        }
-
-        return $diff;
-    }
-    /**
-     * retrieve the last $number versions.
-     *
-     * @param Integer $number the number of record to return.
-     * @return PropelCollection|array \Team\Model\PersonFunctionLinkVersion[] List of \Team\Model\PersonFunctionLinkVersion objects
-     */
-    public function getLastVersions($number = 10, $criteria = null, $con = null)
-    {
-        $criteria = ChildPersonFunctionLinkVersionQuery::create(null, $criteria);
-        $criteria->addDescendingOrderByColumn(PersonFunctionLinkVersionTableMap::VERSION);
-        $criteria->limit($number);
-
-        return $this->getPersonFunctionLinkVersions($criteria, $con);
-    }
     /**
      * Code to be run before persisting the object
      * @param  ConnectionInterface $con

--- a/Model/Base/PersonFunctionLinkQuery.php
+++ b/Model/Base/PersonFunctionLinkQuery.php
@@ -26,18 +26,12 @@ use Team\Model\Map\PersonFunctionLinkTableMap;
  * @method     ChildPersonFunctionLinkQuery orderByFunctionId($order = Criteria::ASC) Order by the function_id column
  * @method     ChildPersonFunctionLinkQuery orderByCreatedAt($order = Criteria::ASC) Order by the created_at column
  * @method     ChildPersonFunctionLinkQuery orderByUpdatedAt($order = Criteria::ASC) Order by the updated_at column
- * @method     ChildPersonFunctionLinkQuery orderByVersion($order = Criteria::ASC) Order by the version column
- * @method     ChildPersonFunctionLinkQuery orderByVersionCreatedAt($order = Criteria::ASC) Order by the version_created_at column
- * @method     ChildPersonFunctionLinkQuery orderByVersionCreatedBy($order = Criteria::ASC) Order by the version_created_by column
  *
  * @method     ChildPersonFunctionLinkQuery groupById() Group by the id column
  * @method     ChildPersonFunctionLinkQuery groupByPersonId() Group by the person_id column
  * @method     ChildPersonFunctionLinkQuery groupByFunctionId() Group by the function_id column
  * @method     ChildPersonFunctionLinkQuery groupByCreatedAt() Group by the created_at column
  * @method     ChildPersonFunctionLinkQuery groupByUpdatedAt() Group by the updated_at column
- * @method     ChildPersonFunctionLinkQuery groupByVersion() Group by the version column
- * @method     ChildPersonFunctionLinkQuery groupByVersionCreatedAt() Group by the version_created_at column
- * @method     ChildPersonFunctionLinkQuery groupByVersionCreatedBy() Group by the version_created_by column
  *
  * @method     ChildPersonFunctionLinkQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
  * @method     ChildPersonFunctionLinkQuery rightJoin($relation) Adds a RIGHT JOIN clause to the query
@@ -51,10 +45,6 @@ use Team\Model\Map\PersonFunctionLinkTableMap;
  * @method     ChildPersonFunctionLinkQuery rightJoinPersonFunction($relationAlias = null) Adds a RIGHT JOIN clause to the query using the PersonFunction relation
  * @method     ChildPersonFunctionLinkQuery innerJoinPersonFunction($relationAlias = null) Adds a INNER JOIN clause to the query using the PersonFunction relation
  *
- * @method     ChildPersonFunctionLinkQuery leftJoinPersonFunctionLinkVersion($relationAlias = null) Adds a LEFT JOIN clause to the query using the PersonFunctionLinkVersion relation
- * @method     ChildPersonFunctionLinkQuery rightJoinPersonFunctionLinkVersion($relationAlias = null) Adds a RIGHT JOIN clause to the query using the PersonFunctionLinkVersion relation
- * @method     ChildPersonFunctionLinkQuery innerJoinPersonFunctionLinkVersion($relationAlias = null) Adds a INNER JOIN clause to the query using the PersonFunctionLinkVersion relation
- *
  * @method     ChildPersonFunctionLink findOne(ConnectionInterface $con = null) Return the first ChildPersonFunctionLink matching the query
  * @method     ChildPersonFunctionLink findOneOrCreate(ConnectionInterface $con = null) Return the first ChildPersonFunctionLink matching the query, or a new ChildPersonFunctionLink object populated from the query conditions when no match is found
  *
@@ -63,29 +53,16 @@ use Team\Model\Map\PersonFunctionLinkTableMap;
  * @method     ChildPersonFunctionLink findOneByFunctionId(int $function_id) Return the first ChildPersonFunctionLink filtered by the function_id column
  * @method     ChildPersonFunctionLink findOneByCreatedAt(string $created_at) Return the first ChildPersonFunctionLink filtered by the created_at column
  * @method     ChildPersonFunctionLink findOneByUpdatedAt(string $updated_at) Return the first ChildPersonFunctionLink filtered by the updated_at column
- * @method     ChildPersonFunctionLink findOneByVersion(int $version) Return the first ChildPersonFunctionLink filtered by the version column
- * @method     ChildPersonFunctionLink findOneByVersionCreatedAt(string $version_created_at) Return the first ChildPersonFunctionLink filtered by the version_created_at column
- * @method     ChildPersonFunctionLink findOneByVersionCreatedBy(string $version_created_by) Return the first ChildPersonFunctionLink filtered by the version_created_by column
  *
  * @method     array findById(int $id) Return ChildPersonFunctionLink objects filtered by the id column
  * @method     array findByPersonId(int $person_id) Return ChildPersonFunctionLink objects filtered by the person_id column
  * @method     array findByFunctionId(int $function_id) Return ChildPersonFunctionLink objects filtered by the function_id column
  * @method     array findByCreatedAt(string $created_at) Return ChildPersonFunctionLink objects filtered by the created_at column
  * @method     array findByUpdatedAt(string $updated_at) Return ChildPersonFunctionLink objects filtered by the updated_at column
- * @method     array findByVersion(int $version) Return ChildPersonFunctionLink objects filtered by the version column
- * @method     array findByVersionCreatedAt(string $version_created_at) Return ChildPersonFunctionLink objects filtered by the version_created_at column
- * @method     array findByVersionCreatedBy(string $version_created_by) Return ChildPersonFunctionLink objects filtered by the version_created_by column
  *
  */
 abstract class PersonFunctionLinkQuery extends ModelCriteria
 {
-
-    // versionable behavior
-
-    /**
-     * Whether the versioning is enabled
-     */
-    static $isVersioningEnabled = true;
 
     /**
      * Initializes internal state of \Team\Model\Base\PersonFunctionLinkQuery object.
@@ -170,7 +147,7 @@ abstract class PersonFunctionLinkQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT ID, PERSON_ID, FUNCTION_ID, CREATED_AT, UPDATED_AT, VERSION, VERSION_CREATED_AT, VERSION_CREATED_BY FROM person_function_link WHERE ID = :p0';
+        $sql = 'SELECT ID, PERSON_ID, FUNCTION_ID, CREATED_AT, UPDATED_AT FROM person_function_link WHERE ID = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -473,119 +450,6 @@ abstract class PersonFunctionLinkQuery extends ModelCriteria
     }
 
     /**
-     * Filter the query on the version column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersion(1234); // WHERE version = 1234
-     * $query->filterByVersion(array(12, 34)); // WHERE version IN (12, 34)
-     * $query->filterByVersion(array('min' => 12)); // WHERE version > 12
-     * </code>
-     *
-     * @param     mixed $version The value to use as filter.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonFunctionLinkQuery The current query, for fluid interface
-     */
-    public function filterByVersion($version = null, $comparison = null)
-    {
-        if (is_array($version)) {
-            $useMinMax = false;
-            if (isset($version['min'])) {
-                $this->addUsingAlias(PersonFunctionLinkTableMap::VERSION, $version['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($version['max'])) {
-                $this->addUsingAlias(PersonFunctionLinkTableMap::VERSION, $version['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(PersonFunctionLinkTableMap::VERSION, $version, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_at column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedAt('2011-03-14'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt('now'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt(array('max' => 'yesterday')); // WHERE version_created_at > '2011-03-13'
-     * </code>
-     *
-     * @param     mixed $versionCreatedAt The value to use as filter.
-     *              Values can be integers (unix timestamps), DateTime objects, or strings.
-     *              Empty strings are treated as NULL.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonFunctionLinkQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedAt($versionCreatedAt = null, $comparison = null)
-    {
-        if (is_array($versionCreatedAt)) {
-            $useMinMax = false;
-            if (isset($versionCreatedAt['min'])) {
-                $this->addUsingAlias(PersonFunctionLinkTableMap::VERSION_CREATED_AT, $versionCreatedAt['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($versionCreatedAt['max'])) {
-                $this->addUsingAlias(PersonFunctionLinkTableMap::VERSION_CREATED_AT, $versionCreatedAt['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(PersonFunctionLinkTableMap::VERSION_CREATED_AT, $versionCreatedAt, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_by column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedBy('fooValue');   // WHERE version_created_by = 'fooValue'
-     * $query->filterByVersionCreatedBy('%fooValue%'); // WHERE version_created_by LIKE '%fooValue%'
-     * </code>
-     *
-     * @param     string $versionCreatedBy The value to use as filter.
-     *              Accepts wildcards (* and % trigger a LIKE)
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonFunctionLinkQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedBy($versionCreatedBy = null, $comparison = null)
-    {
-        if (null === $comparison) {
-            if (is_array($versionCreatedBy)) {
-                $comparison = Criteria::IN;
-            } elseif (preg_match('/[\%\*]/', $versionCreatedBy)) {
-                $versionCreatedBy = str_replace('*', '%', $versionCreatedBy);
-                $comparison = Criteria::LIKE;
-            }
-        }
-
-        return $this->addUsingAlias(PersonFunctionLinkTableMap::VERSION_CREATED_BY, $versionCreatedBy, $comparison);
-    }
-
-    /**
      * Filter the query by a related \Team\Model\Person object
      *
      * @param \Team\Model\Person|ObjectCollection $person The related object(s) to use as filter
@@ -733,79 +597,6 @@ abstract class PersonFunctionLinkQuery extends ModelCriteria
         return $this
             ->joinPersonFunction($relationAlias, $joinType)
             ->useQuery($relationAlias ? $relationAlias : 'PersonFunction', '\Team\Model\PersonFunctionQuery');
-    }
-
-    /**
-     * Filter the query by a related \Team\Model\PersonFunctionLinkVersion object
-     *
-     * @param \Team\Model\PersonFunctionLinkVersion|ObjectCollection $personFunctionLinkVersion  the related object to use as filter
-     * @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonFunctionLinkQuery The current query, for fluid interface
-     */
-    public function filterByPersonFunctionLinkVersion($personFunctionLinkVersion, $comparison = null)
-    {
-        if ($personFunctionLinkVersion instanceof \Team\Model\PersonFunctionLinkVersion) {
-            return $this
-                ->addUsingAlias(PersonFunctionLinkTableMap::ID, $personFunctionLinkVersion->getId(), $comparison);
-        } elseif ($personFunctionLinkVersion instanceof ObjectCollection) {
-            return $this
-                ->usePersonFunctionLinkVersionQuery()
-                ->filterByPrimaryKeys($personFunctionLinkVersion->getPrimaryKeys())
-                ->endUse();
-        } else {
-            throw new PropelException('filterByPersonFunctionLinkVersion() only accepts arguments of type \Team\Model\PersonFunctionLinkVersion or Collection');
-        }
-    }
-
-    /**
-     * Adds a JOIN clause to the query using the PersonFunctionLinkVersion relation
-     *
-     * @param     string $relationAlias optional alias for the relation
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return ChildPersonFunctionLinkQuery The current query, for fluid interface
-     */
-    public function joinPersonFunctionLinkVersion($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        $tableMap = $this->getTableMap();
-        $relationMap = $tableMap->getRelation('PersonFunctionLinkVersion');
-
-        // create a ModelJoin object for this join
-        $join = new ModelJoin();
-        $join->setJoinType($joinType);
-        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
-        if ($previousJoin = $this->getPreviousJoin()) {
-            $join->setPreviousJoin($previousJoin);
-        }
-
-        // add the ModelJoin to the current object
-        if ($relationAlias) {
-            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
-            $this->addJoinObject($join, $relationAlias);
-        } else {
-            $this->addJoinObject($join, 'PersonFunctionLinkVersion');
-        }
-
-        return $this;
-    }
-
-    /**
-     * Use the PersonFunctionLinkVersion relation PersonFunctionLinkVersion object
-     *
-     * @see useQuery()
-     *
-     * @param     string $relationAlias optional alias for the relation,
-     *                                   to be used as main alias in the secondary query
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return   \Team\Model\PersonFunctionLinkVersionQuery A secondary query class using the current class as primary query
-     */
-    public function usePersonFunctionLinkVersionQuery($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        return $this
-            ->joinPersonFunctionLinkVersion($relationAlias, $joinType)
-            ->useQuery($relationAlias ? $relationAlias : 'PersonFunctionLinkVersion', '\Team\Model\PersonFunctionLinkVersionQuery');
     }
 
     /**
@@ -963,34 +754,6 @@ abstract class PersonFunctionLinkQuery extends ModelCriteria
     public function firstCreatedFirst()
     {
         return $this->addAscendingOrderByColumn(PersonFunctionLinkTableMap::CREATED_AT);
-    }
-
-    // versionable behavior
-
-    /**
-     * Checks whether versioning is enabled
-     *
-     * @return boolean
-     */
-    static public function isVersioningEnabled()
-    {
-        return self::$isVersioningEnabled;
-    }
-
-    /**
-     * Enables versioning
-     */
-    static public function enableVersioning()
-    {
-        self::$isVersioningEnabled = true;
-    }
-
-    /**
-     * Disables versioning
-     */
-    static public function disableVersioning()
-    {
-        self::$isVersioningEnabled = false;
     }
 
 } // PersonFunctionLinkQuery

--- a/Model/Base/PersonFunctionQuery.php
+++ b/Model/Base/PersonFunctionQuery.php
@@ -26,17 +26,11 @@ use Team\Model\Map\PersonFunctionTableMap;
  * @method     ChildPersonFunctionQuery orderByCode($order = Criteria::ASC) Order by the code column
  * @method     ChildPersonFunctionQuery orderByCreatedAt($order = Criteria::ASC) Order by the created_at column
  * @method     ChildPersonFunctionQuery orderByUpdatedAt($order = Criteria::ASC) Order by the updated_at column
- * @method     ChildPersonFunctionQuery orderByVersion($order = Criteria::ASC) Order by the version column
- * @method     ChildPersonFunctionQuery orderByVersionCreatedAt($order = Criteria::ASC) Order by the version_created_at column
- * @method     ChildPersonFunctionQuery orderByVersionCreatedBy($order = Criteria::ASC) Order by the version_created_by column
  *
  * @method     ChildPersonFunctionQuery groupById() Group by the id column
  * @method     ChildPersonFunctionQuery groupByCode() Group by the code column
  * @method     ChildPersonFunctionQuery groupByCreatedAt() Group by the created_at column
  * @method     ChildPersonFunctionQuery groupByUpdatedAt() Group by the updated_at column
- * @method     ChildPersonFunctionQuery groupByVersion() Group by the version column
- * @method     ChildPersonFunctionQuery groupByVersionCreatedAt() Group by the version_created_at column
- * @method     ChildPersonFunctionQuery groupByVersionCreatedBy() Group by the version_created_by column
  *
  * @method     ChildPersonFunctionQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
  * @method     ChildPersonFunctionQuery rightJoin($relation) Adds a RIGHT JOIN clause to the query
@@ -50,10 +44,6 @@ use Team\Model\Map\PersonFunctionTableMap;
  * @method     ChildPersonFunctionQuery rightJoinPersonFunctionI18n($relationAlias = null) Adds a RIGHT JOIN clause to the query using the PersonFunctionI18n relation
  * @method     ChildPersonFunctionQuery innerJoinPersonFunctionI18n($relationAlias = null) Adds a INNER JOIN clause to the query using the PersonFunctionI18n relation
  *
- * @method     ChildPersonFunctionQuery leftJoinPersonFunctionVersion($relationAlias = null) Adds a LEFT JOIN clause to the query using the PersonFunctionVersion relation
- * @method     ChildPersonFunctionQuery rightJoinPersonFunctionVersion($relationAlias = null) Adds a RIGHT JOIN clause to the query using the PersonFunctionVersion relation
- * @method     ChildPersonFunctionQuery innerJoinPersonFunctionVersion($relationAlias = null) Adds a INNER JOIN clause to the query using the PersonFunctionVersion relation
- *
  * @method     ChildPersonFunction findOne(ConnectionInterface $con = null) Return the first ChildPersonFunction matching the query
  * @method     ChildPersonFunction findOneOrCreate(ConnectionInterface $con = null) Return the first ChildPersonFunction matching the query, or a new ChildPersonFunction object populated from the query conditions when no match is found
  *
@@ -61,28 +51,15 @@ use Team\Model\Map\PersonFunctionTableMap;
  * @method     ChildPersonFunction findOneByCode(string $code) Return the first ChildPersonFunction filtered by the code column
  * @method     ChildPersonFunction findOneByCreatedAt(string $created_at) Return the first ChildPersonFunction filtered by the created_at column
  * @method     ChildPersonFunction findOneByUpdatedAt(string $updated_at) Return the first ChildPersonFunction filtered by the updated_at column
- * @method     ChildPersonFunction findOneByVersion(int $version) Return the first ChildPersonFunction filtered by the version column
- * @method     ChildPersonFunction findOneByVersionCreatedAt(string $version_created_at) Return the first ChildPersonFunction filtered by the version_created_at column
- * @method     ChildPersonFunction findOneByVersionCreatedBy(string $version_created_by) Return the first ChildPersonFunction filtered by the version_created_by column
  *
  * @method     array findById(int $id) Return ChildPersonFunction objects filtered by the id column
  * @method     array findByCode(string $code) Return ChildPersonFunction objects filtered by the code column
  * @method     array findByCreatedAt(string $created_at) Return ChildPersonFunction objects filtered by the created_at column
  * @method     array findByUpdatedAt(string $updated_at) Return ChildPersonFunction objects filtered by the updated_at column
- * @method     array findByVersion(int $version) Return ChildPersonFunction objects filtered by the version column
- * @method     array findByVersionCreatedAt(string $version_created_at) Return ChildPersonFunction objects filtered by the version_created_at column
- * @method     array findByVersionCreatedBy(string $version_created_by) Return ChildPersonFunction objects filtered by the version_created_by column
  *
  */
 abstract class PersonFunctionQuery extends ModelCriteria
 {
-
-    // versionable behavior
-
-    /**
-     * Whether the versioning is enabled
-     */
-    static $isVersioningEnabled = true;
 
     /**
      * Initializes internal state of \Team\Model\Base\PersonFunctionQuery object.
@@ -167,7 +144,7 @@ abstract class PersonFunctionQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT ID, CODE, CREATED_AT, UPDATED_AT, VERSION, VERSION_CREATED_AT, VERSION_CREATED_BY FROM person_function WHERE ID = :p0';
+        $sql = 'SELECT ID, CODE, CREATED_AT, UPDATED_AT FROM person_function WHERE ID = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -413,119 +390,6 @@ abstract class PersonFunctionQuery extends ModelCriteria
     }
 
     /**
-     * Filter the query on the version column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersion(1234); // WHERE version = 1234
-     * $query->filterByVersion(array(12, 34)); // WHERE version IN (12, 34)
-     * $query->filterByVersion(array('min' => 12)); // WHERE version > 12
-     * </code>
-     *
-     * @param     mixed $version The value to use as filter.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonFunctionQuery The current query, for fluid interface
-     */
-    public function filterByVersion($version = null, $comparison = null)
-    {
-        if (is_array($version)) {
-            $useMinMax = false;
-            if (isset($version['min'])) {
-                $this->addUsingAlias(PersonFunctionTableMap::VERSION, $version['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($version['max'])) {
-                $this->addUsingAlias(PersonFunctionTableMap::VERSION, $version['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(PersonFunctionTableMap::VERSION, $version, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_at column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedAt('2011-03-14'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt('now'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt(array('max' => 'yesterday')); // WHERE version_created_at > '2011-03-13'
-     * </code>
-     *
-     * @param     mixed $versionCreatedAt The value to use as filter.
-     *              Values can be integers (unix timestamps), DateTime objects, or strings.
-     *              Empty strings are treated as NULL.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonFunctionQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedAt($versionCreatedAt = null, $comparison = null)
-    {
-        if (is_array($versionCreatedAt)) {
-            $useMinMax = false;
-            if (isset($versionCreatedAt['min'])) {
-                $this->addUsingAlias(PersonFunctionTableMap::VERSION_CREATED_AT, $versionCreatedAt['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($versionCreatedAt['max'])) {
-                $this->addUsingAlias(PersonFunctionTableMap::VERSION_CREATED_AT, $versionCreatedAt['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(PersonFunctionTableMap::VERSION_CREATED_AT, $versionCreatedAt, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_by column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedBy('fooValue');   // WHERE version_created_by = 'fooValue'
-     * $query->filterByVersionCreatedBy('%fooValue%'); // WHERE version_created_by LIKE '%fooValue%'
-     * </code>
-     *
-     * @param     string $versionCreatedBy The value to use as filter.
-     *              Accepts wildcards (* and % trigger a LIKE)
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonFunctionQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedBy($versionCreatedBy = null, $comparison = null)
-    {
-        if (null === $comparison) {
-            if (is_array($versionCreatedBy)) {
-                $comparison = Criteria::IN;
-            } elseif (preg_match('/[\%\*]/', $versionCreatedBy)) {
-                $versionCreatedBy = str_replace('*', '%', $versionCreatedBy);
-                $comparison = Criteria::LIKE;
-            }
-        }
-
-        return $this->addUsingAlias(PersonFunctionTableMap::VERSION_CREATED_BY, $versionCreatedBy, $comparison);
-    }
-
-    /**
      * Filter the query by a related \Team\Model\PersonFunctionLink object
      *
      * @param \Team\Model\PersonFunctionLink|ObjectCollection $personFunctionLink  the related object to use as filter
@@ -669,79 +533,6 @@ abstract class PersonFunctionQuery extends ModelCriteria
         return $this
             ->joinPersonFunctionI18n($relationAlias, $joinType)
             ->useQuery($relationAlias ? $relationAlias : 'PersonFunctionI18n', '\Team\Model\PersonFunctionI18nQuery');
-    }
-
-    /**
-     * Filter the query by a related \Team\Model\PersonFunctionVersion object
-     *
-     * @param \Team\Model\PersonFunctionVersion|ObjectCollection $personFunctionVersion  the related object to use as filter
-     * @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonFunctionQuery The current query, for fluid interface
-     */
-    public function filterByPersonFunctionVersion($personFunctionVersion, $comparison = null)
-    {
-        if ($personFunctionVersion instanceof \Team\Model\PersonFunctionVersion) {
-            return $this
-                ->addUsingAlias(PersonFunctionTableMap::ID, $personFunctionVersion->getId(), $comparison);
-        } elseif ($personFunctionVersion instanceof ObjectCollection) {
-            return $this
-                ->usePersonFunctionVersionQuery()
-                ->filterByPrimaryKeys($personFunctionVersion->getPrimaryKeys())
-                ->endUse();
-        } else {
-            throw new PropelException('filterByPersonFunctionVersion() only accepts arguments of type \Team\Model\PersonFunctionVersion or Collection');
-        }
-    }
-
-    /**
-     * Adds a JOIN clause to the query using the PersonFunctionVersion relation
-     *
-     * @param     string $relationAlias optional alias for the relation
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return ChildPersonFunctionQuery The current query, for fluid interface
-     */
-    public function joinPersonFunctionVersion($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        $tableMap = $this->getTableMap();
-        $relationMap = $tableMap->getRelation('PersonFunctionVersion');
-
-        // create a ModelJoin object for this join
-        $join = new ModelJoin();
-        $join->setJoinType($joinType);
-        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
-        if ($previousJoin = $this->getPreviousJoin()) {
-            $join->setPreviousJoin($previousJoin);
-        }
-
-        // add the ModelJoin to the current object
-        if ($relationAlias) {
-            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
-            $this->addJoinObject($join, $relationAlias);
-        } else {
-            $this->addJoinObject($join, 'PersonFunctionVersion');
-        }
-
-        return $this;
-    }
-
-    /**
-     * Use the PersonFunctionVersion relation PersonFunctionVersion object
-     *
-     * @see useQuery()
-     *
-     * @param     string $relationAlias optional alias for the relation,
-     *                                   to be used as main alias in the secondary query
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return   \Team\Model\PersonFunctionVersionQuery A secondary query class using the current class as primary query
-     */
-    public function usePersonFunctionVersionQuery($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        return $this
-            ->joinPersonFunctionVersion($relationAlias, $joinType)
-            ->useQuery($relationAlias ? $relationAlias : 'PersonFunctionVersion', '\Team\Model\PersonFunctionVersionQuery');
     }
 
     /**
@@ -956,34 +747,6 @@ abstract class PersonFunctionQuery extends ModelCriteria
         return $this
             ->joinI18n($locale, $relationAlias, $joinType)
             ->useQuery($relationAlias ? $relationAlias : 'PersonFunctionI18n', '\Team\Model\PersonFunctionI18nQuery');
-    }
-
-    // versionable behavior
-
-    /**
-     * Checks whether versioning is enabled
-     *
-     * @return boolean
-     */
-    static public function isVersioningEnabled()
-    {
-        return self::$isVersioningEnabled;
-    }
-
-    /**
-     * Enables versioning
-     */
-    static public function enableVersioning()
-    {
-        self::$isVersioningEnabled = true;
-    }
-
-    /**
-     * Disables versioning
-     */
-    static public function disableVersioning()
-    {
-        self::$isVersioningEnabled = false;
     }
 
 } // PersonFunctionQuery

--- a/Model/Base/PersonImage.php
+++ b/Model/Base/PersonImage.php
@@ -22,12 +22,8 @@ use Team\Model\PersonImage as ChildPersonImage;
 use Team\Model\PersonImageI18n as ChildPersonImageI18n;
 use Team\Model\PersonImageI18nQuery as ChildPersonImageI18nQuery;
 use Team\Model\PersonImageQuery as ChildPersonImageQuery;
-use Team\Model\PersonImageVersion as ChildPersonImageVersion;
-use Team\Model\PersonImageVersionQuery as ChildPersonImageVersionQuery;
 use Team\Model\PersonQuery as ChildPersonQuery;
-use Team\Model\PersonVersionQuery as ChildPersonVersionQuery;
 use Team\Model\Map\PersonImageTableMap;
-use Team\Model\Map\PersonImageVersionTableMap;
 
 abstract class PersonImage implements ActiveRecordInterface
 {
@@ -107,25 +103,6 @@ abstract class PersonImage implements ActiveRecordInterface
     protected $updated_at;
 
     /**
-     * The value for the version field.
-     * Note: this column has a database default value of: 0
-     * @var        int
-     */
-    protected $version;
-
-    /**
-     * The value for the version_created_at field.
-     * @var        string
-     */
-    protected $version_created_at;
-
-    /**
-     * The value for the version_created_by field.
-     * @var        string
-     */
-    protected $version_created_by;
-
-    /**
      * @var        Person
      */
     protected $aPerson;
@@ -135,12 +112,6 @@ abstract class PersonImage implements ActiveRecordInterface
      */
     protected $collPersonImageI18ns;
     protected $collPersonImageI18nsPartial;
-
-    /**
-     * @var        ObjectCollection|ChildPersonImageVersion[] Collection to store aggregation of ChildPersonImageVersion objects.
-     */
-    protected $collPersonImageVersions;
-    protected $collPersonImageVersionsPartial;
 
     /**
      * Flag to prevent endless save loop, if this object is referenced
@@ -164,25 +135,11 @@ abstract class PersonImage implements ActiveRecordInterface
      */
     protected $currentTranslations;
 
-    // versionable behavior
-
-
-    /**
-     * @var bool
-     */
-    protected $enforceVersion = false;
-
     /**
      * An array of objects scheduled for deletion.
      * @var ObjectCollection
      */
     protected $personImageI18nsScheduledForDeletion = null;
-
-    /**
-     * An array of objects scheduled for deletion.
-     * @var ObjectCollection
-     */
-    protected $personImageVersionsScheduledForDeletion = null;
 
     /**
      * Applies default values to this object.
@@ -193,7 +150,6 @@ abstract class PersonImage implements ActiveRecordInterface
     public function applyDefaultValues()
     {
         $this->visible = 1;
-        $this->version = 0;
     }
 
     /**
@@ -552,48 +508,6 @@ abstract class PersonImage implements ActiveRecordInterface
     }
 
     /**
-     * Get the [version] column value.
-     *
-     * @return   int
-     */
-    public function getVersion()
-    {
-
-        return $this->version;
-    }
-
-    /**
-     * Get the [optionally formatted] temporal [version_created_at] column value.
-     *
-     *
-     * @param      string $format The date/time format string (either date()-style or strftime()-style).
-     *                            If format is NULL, then the raw \DateTime object will be returned.
-     *
-     * @return mixed Formatted date/time value as string or \DateTime object (if format is NULL), NULL if column is NULL, and 0 if column value is 0000-00-00 00:00:00
-     *
-     * @throws PropelException - if unable to parse/validate the date/time value.
-     */
-    public function getVersionCreatedAt($format = NULL)
-    {
-        if ($format === null) {
-            return $this->version_created_at;
-        } else {
-            return $this->version_created_at instanceof \DateTime ? $this->version_created_at->format($format) : null;
-        }
-    }
-
-    /**
-     * Get the [version_created_by] column value.
-     *
-     * @return   string
-     */
-    public function getVersionCreatedBy()
-    {
-
-        return $this->version_created_by;
-    }
-
-    /**
      * Set the value of [id] column.
      *
      * @param      int $v new value
@@ -745,69 +659,6 @@ abstract class PersonImage implements ActiveRecordInterface
     } // setUpdatedAt()
 
     /**
-     * Set the value of [version] column.
-     *
-     * @param      int $v new value
-     * @return   \Team\Model\PersonImage The current object (for fluent API support)
-     */
-    public function setVersion($v)
-    {
-        if ($v !== null) {
-            $v = (int) $v;
-        }
-
-        if ($this->version !== $v) {
-            $this->version = $v;
-            $this->modifiedColumns[PersonImageTableMap::VERSION] = true;
-        }
-
-
-        return $this;
-    } // setVersion()
-
-    /**
-     * Sets the value of [version_created_at] column to a normalized version of the date/time value specified.
-     *
-     * @param      mixed $v string, integer (timestamp), or \DateTime value.
-     *               Empty strings are treated as NULL.
-     * @return   \Team\Model\PersonImage The current object (for fluent API support)
-     */
-    public function setVersionCreatedAt($v)
-    {
-        $dt = PropelDateTime::newInstance($v, null, '\DateTime');
-        if ($this->version_created_at !== null || $dt !== null) {
-            if ($dt !== $this->version_created_at) {
-                $this->version_created_at = $dt;
-                $this->modifiedColumns[PersonImageTableMap::VERSION_CREATED_AT] = true;
-            }
-        } // if either are not null
-
-
-        return $this;
-    } // setVersionCreatedAt()
-
-    /**
-     * Set the value of [version_created_by] column.
-     *
-     * @param      string $v new value
-     * @return   \Team\Model\PersonImage The current object (for fluent API support)
-     */
-    public function setVersionCreatedBy($v)
-    {
-        if ($v !== null) {
-            $v = (string) $v;
-        }
-
-        if ($this->version_created_by !== $v) {
-            $this->version_created_by = $v;
-            $this->modifiedColumns[PersonImageTableMap::VERSION_CREATED_BY] = true;
-        }
-
-
-        return $this;
-    } // setVersionCreatedBy()
-
-    /**
      * Indicates whether the columns in this object are only set to default values.
      *
      * This method can be used in conjunction with isModified() to indicate whether an object is both
@@ -818,10 +669,6 @@ abstract class PersonImage implements ActiveRecordInterface
     public function hasOnlyDefaultValues()
     {
             if ($this->visible !== 1) {
-                return false;
-            }
-
-            if ($this->version !== 0) {
                 return false;
             }
 
@@ -878,18 +725,6 @@ abstract class PersonImage implements ActiveRecordInterface
                 $col = null;
             }
             $this->updated_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : PersonImageTableMap::translateFieldName('Version', TableMap::TYPE_PHPNAME, $indexType)];
-            $this->version = (null !== $col) ? (int) $col : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 8 + $startcol : PersonImageTableMap::translateFieldName('VersionCreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
-            if ($col === '0000-00-00 00:00:00') {
-                $col = null;
-            }
-            $this->version_created_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 9 + $startcol : PersonImageTableMap::translateFieldName('VersionCreatedBy', TableMap::TYPE_PHPNAME, $indexType)];
-            $this->version_created_by = (null !== $col) ? (string) $col : null;
             $this->resetModified();
 
             $this->setNew(false);
@@ -898,7 +733,7 @@ abstract class PersonImage implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 10; // 10 = PersonImageTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 7; // 7 = PersonImageTableMap::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception $e) {
             throw new PropelException("Error populating \Team\Model\PersonImage object", 0, $e);
@@ -964,8 +799,6 @@ abstract class PersonImage implements ActiveRecordInterface
 
             $this->aPerson = null;
             $this->collPersonImageI18ns = null;
-
-            $this->collPersonImageVersions = null;
 
         } // if (deep)
     }
@@ -1035,14 +868,6 @@ abstract class PersonImage implements ActiveRecordInterface
         $isInsert = $this->isNew();
         try {
             $ret = $this->preSave($con);
-            // versionable behavior
-            if ($this->isVersioningNecessary()) {
-                $this->setVersion($this->isNew() ? 1 : $this->getLastVersionNumber($con) + 1);
-                if (!$this->isColumnModified(PersonImageTableMap::VERSION_CREATED_AT)) {
-                    $this->setVersionCreatedAt(time());
-                }
-                $createVersion = true; // for postSave hook
-            }
             if ($isInsert) {
                 $ret = $ret && $this->preInsert($con);
                 // timestampable behavior
@@ -1067,10 +892,6 @@ abstract class PersonImage implements ActiveRecordInterface
                     $this->postUpdate($con);
                 }
                 $this->postSave($con);
-                // versionable behavior
-                if (isset($createVersion)) {
-                    $this->addVersion($con);
-                }
                 PersonImageTableMap::addInstanceToPool($this);
             } else {
                 $affectedRows = 0;
@@ -1141,23 +962,6 @@ abstract class PersonImage implements ActiveRecordInterface
                 }
             }
 
-            if ($this->personImageVersionsScheduledForDeletion !== null) {
-                if (!$this->personImageVersionsScheduledForDeletion->isEmpty()) {
-                    \Team\Model\PersonImageVersionQuery::create()
-                        ->filterByPrimaryKeys($this->personImageVersionsScheduledForDeletion->getPrimaryKeys(false))
-                        ->delete($con);
-                    $this->personImageVersionsScheduledForDeletion = null;
-                }
-            }
-
-                if ($this->collPersonImageVersions !== null) {
-            foreach ($this->collPersonImageVersions as $referrerFK) {
-                    if (!$referrerFK->isDeleted() && ($referrerFK->isNew() || $referrerFK->isModified())) {
-                        $affectedRows += $referrerFK->save($con);
-                    }
-                }
-            }
-
             $this->alreadyInSave = false;
 
         }
@@ -1205,15 +1009,6 @@ abstract class PersonImage implements ActiveRecordInterface
         if ($this->isColumnModified(PersonImageTableMap::UPDATED_AT)) {
             $modifiedColumns[':p' . $index++]  = 'UPDATED_AT';
         }
-        if ($this->isColumnModified(PersonImageTableMap::VERSION)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION';
-        }
-        if ($this->isColumnModified(PersonImageTableMap::VERSION_CREATED_AT)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION_CREATED_AT';
-        }
-        if ($this->isColumnModified(PersonImageTableMap::VERSION_CREATED_BY)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION_CREATED_BY';
-        }
 
         $sql = sprintf(
             'INSERT INTO person_image (%s) VALUES (%s)',
@@ -1245,15 +1040,6 @@ abstract class PersonImage implements ActiveRecordInterface
                         break;
                     case 'UPDATED_AT':
                         $stmt->bindValue($identifier, $this->updated_at ? $this->updated_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
-                        break;
-                    case 'VERSION':
-                        $stmt->bindValue($identifier, $this->version, PDO::PARAM_INT);
-                        break;
-                    case 'VERSION_CREATED_AT':
-                        $stmt->bindValue($identifier, $this->version_created_at ? $this->version_created_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
-                        break;
-                    case 'VERSION_CREATED_BY':
-                        $stmt->bindValue($identifier, $this->version_created_by, PDO::PARAM_STR);
                         break;
                 }
             }
@@ -1338,15 +1124,6 @@ abstract class PersonImage implements ActiveRecordInterface
             case 6:
                 return $this->getUpdatedAt();
                 break;
-            case 7:
-                return $this->getVersion();
-                break;
-            case 8:
-                return $this->getVersionCreatedAt();
-                break;
-            case 9:
-                return $this->getVersionCreatedBy();
-                break;
             default:
                 return null;
                 break;
@@ -1383,9 +1160,6 @@ abstract class PersonImage implements ActiveRecordInterface
             $keys[4] => $this->getPosition(),
             $keys[5] => $this->getCreatedAt(),
             $keys[6] => $this->getUpdatedAt(),
-            $keys[7] => $this->getVersion(),
-            $keys[8] => $this->getVersionCreatedAt(),
-            $keys[9] => $this->getVersionCreatedBy(),
         );
         $virtualColumns = $this->virtualColumns;
         foreach ($virtualColumns as $key => $virtualColumn) {
@@ -1398,9 +1172,6 @@ abstract class PersonImage implements ActiveRecordInterface
             }
             if (null !== $this->collPersonImageI18ns) {
                 $result['PersonImageI18ns'] = $this->collPersonImageI18ns->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
-            }
-            if (null !== $this->collPersonImageVersions) {
-                $result['PersonImageVersions'] = $this->collPersonImageVersions->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
             }
         }
 
@@ -1457,15 +1228,6 @@ abstract class PersonImage implements ActiveRecordInterface
             case 6:
                 $this->setUpdatedAt($value);
                 break;
-            case 7:
-                $this->setVersion($value);
-                break;
-            case 8:
-                $this->setVersionCreatedAt($value);
-                break;
-            case 9:
-                $this->setVersionCreatedBy($value);
-                break;
         } // switch()
     }
 
@@ -1497,9 +1259,6 @@ abstract class PersonImage implements ActiveRecordInterface
         if (array_key_exists($keys[4], $arr)) $this->setPosition($arr[$keys[4]]);
         if (array_key_exists($keys[5], $arr)) $this->setCreatedAt($arr[$keys[5]]);
         if (array_key_exists($keys[6], $arr)) $this->setUpdatedAt($arr[$keys[6]]);
-        if (array_key_exists($keys[7], $arr)) $this->setVersion($arr[$keys[7]]);
-        if (array_key_exists($keys[8], $arr)) $this->setVersionCreatedAt($arr[$keys[8]]);
-        if (array_key_exists($keys[9], $arr)) $this->setVersionCreatedBy($arr[$keys[9]]);
     }
 
     /**
@@ -1518,9 +1277,6 @@ abstract class PersonImage implements ActiveRecordInterface
         if ($this->isColumnModified(PersonImageTableMap::POSITION)) $criteria->add(PersonImageTableMap::POSITION, $this->position);
         if ($this->isColumnModified(PersonImageTableMap::CREATED_AT)) $criteria->add(PersonImageTableMap::CREATED_AT, $this->created_at);
         if ($this->isColumnModified(PersonImageTableMap::UPDATED_AT)) $criteria->add(PersonImageTableMap::UPDATED_AT, $this->updated_at);
-        if ($this->isColumnModified(PersonImageTableMap::VERSION)) $criteria->add(PersonImageTableMap::VERSION, $this->version);
-        if ($this->isColumnModified(PersonImageTableMap::VERSION_CREATED_AT)) $criteria->add(PersonImageTableMap::VERSION_CREATED_AT, $this->version_created_at);
-        if ($this->isColumnModified(PersonImageTableMap::VERSION_CREATED_BY)) $criteria->add(PersonImageTableMap::VERSION_CREATED_BY, $this->version_created_by);
 
         return $criteria;
     }
@@ -1590,9 +1346,6 @@ abstract class PersonImage implements ActiveRecordInterface
         $copyObj->setPosition($this->getPosition());
         $copyObj->setCreatedAt($this->getCreatedAt());
         $copyObj->setUpdatedAt($this->getUpdatedAt());
-        $copyObj->setVersion($this->getVersion());
-        $copyObj->setVersionCreatedAt($this->getVersionCreatedAt());
-        $copyObj->setVersionCreatedBy($this->getVersionCreatedBy());
 
         if ($deepCopy) {
             // important: temporarily setNew(false) because this affects the behavior of
@@ -1602,12 +1355,6 @@ abstract class PersonImage implements ActiveRecordInterface
             foreach ($this->getPersonImageI18ns() as $relObj) {
                 if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
                     $copyObj->addPersonImageI18n($relObj->copy($deepCopy));
-                }
-            }
-
-            foreach ($this->getPersonImageVersions() as $relObj) {
-                if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
-                    $copyObj->addPersonImageVersion($relObj->copy($deepCopy));
                 }
             }
 
@@ -1705,9 +1452,6 @@ abstract class PersonImage implements ActiveRecordInterface
     {
         if ('PersonImageI18n' == $relationName) {
             return $this->initPersonImageI18ns();
-        }
-        if ('PersonImageVersion' == $relationName) {
-            return $this->initPersonImageVersions();
         }
     }
 
@@ -1937,227 +1681,6 @@ abstract class PersonImage implements ActiveRecordInterface
     }
 
     /**
-     * Clears out the collPersonImageVersions collection
-     *
-     * This does not modify the database; however, it will remove any associated objects, causing
-     * them to be refetched by subsequent calls to accessor method.
-     *
-     * @return void
-     * @see        addPersonImageVersions()
-     */
-    public function clearPersonImageVersions()
-    {
-        $this->collPersonImageVersions = null; // important to set this to NULL since that means it is uninitialized
-    }
-
-    /**
-     * Reset is the collPersonImageVersions collection loaded partially.
-     */
-    public function resetPartialPersonImageVersions($v = true)
-    {
-        $this->collPersonImageVersionsPartial = $v;
-    }
-
-    /**
-     * Initializes the collPersonImageVersions collection.
-     *
-     * By default this just sets the collPersonImageVersions collection to an empty array (like clearcollPersonImageVersions());
-     * however, you may wish to override this method in your stub class to provide setting appropriate
-     * to your application -- for example, setting the initial array to the values stored in database.
-     *
-     * @param      boolean $overrideExisting If set to true, the method call initializes
-     *                                        the collection even if it is not empty
-     *
-     * @return void
-     */
-    public function initPersonImageVersions($overrideExisting = true)
-    {
-        if (null !== $this->collPersonImageVersions && !$overrideExisting) {
-            return;
-        }
-        $this->collPersonImageVersions = new ObjectCollection();
-        $this->collPersonImageVersions->setModel('\Team\Model\PersonImageVersion');
-    }
-
-    /**
-     * Gets an array of ChildPersonImageVersion objects which contain a foreign key that references this object.
-     *
-     * If the $criteria is not null, it is used to always fetch the results from the database.
-     * Otherwise the results are fetched from the database the first time, then cached.
-     * Next time the same method is called without $criteria, the cached collection is returned.
-     * If this ChildPersonImage is new, it will return
-     * an empty collection or the current collection; the criteria is ignored on a new object.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @return Collection|ChildPersonImageVersion[] List of ChildPersonImageVersion objects
-     * @throws PropelException
-     */
-    public function getPersonImageVersions($criteria = null, ConnectionInterface $con = null)
-    {
-        $partial = $this->collPersonImageVersionsPartial && !$this->isNew();
-        if (null === $this->collPersonImageVersions || null !== $criteria  || $partial) {
-            if ($this->isNew() && null === $this->collPersonImageVersions) {
-                // return empty collection
-                $this->initPersonImageVersions();
-            } else {
-                $collPersonImageVersions = ChildPersonImageVersionQuery::create(null, $criteria)
-                    ->filterByPersonImage($this)
-                    ->find($con);
-
-                if (null !== $criteria) {
-                    if (false !== $this->collPersonImageVersionsPartial && count($collPersonImageVersions)) {
-                        $this->initPersonImageVersions(false);
-
-                        foreach ($collPersonImageVersions as $obj) {
-                            if (false == $this->collPersonImageVersions->contains($obj)) {
-                                $this->collPersonImageVersions->append($obj);
-                            }
-                        }
-
-                        $this->collPersonImageVersionsPartial = true;
-                    }
-
-                    reset($collPersonImageVersions);
-
-                    return $collPersonImageVersions;
-                }
-
-                if ($partial && $this->collPersonImageVersions) {
-                    foreach ($this->collPersonImageVersions as $obj) {
-                        if ($obj->isNew()) {
-                            $collPersonImageVersions[] = $obj;
-                        }
-                    }
-                }
-
-                $this->collPersonImageVersions = $collPersonImageVersions;
-                $this->collPersonImageVersionsPartial = false;
-            }
-        }
-
-        return $this->collPersonImageVersions;
-    }
-
-    /**
-     * Sets a collection of PersonImageVersion objects related by a one-to-many relationship
-     * to the current object.
-     * It will also schedule objects for deletion based on a diff between old objects (aka persisted)
-     * and new objects from the given Propel collection.
-     *
-     * @param      Collection $personImageVersions A Propel collection.
-     * @param      ConnectionInterface $con Optional connection object
-     * @return   ChildPersonImage The current object (for fluent API support)
-     */
-    public function setPersonImageVersions(Collection $personImageVersions, ConnectionInterface $con = null)
-    {
-        $personImageVersionsToDelete = $this->getPersonImageVersions(new Criteria(), $con)->diff($personImageVersions);
-
-
-        //since at least one column in the foreign key is at the same time a PK
-        //we can not just set a PK to NULL in the lines below. We have to store
-        //a backup of all values, so we are able to manipulate these items based on the onDelete value later.
-        $this->personImageVersionsScheduledForDeletion = clone $personImageVersionsToDelete;
-
-        foreach ($personImageVersionsToDelete as $personImageVersionRemoved) {
-            $personImageVersionRemoved->setPersonImage(null);
-        }
-
-        $this->collPersonImageVersions = null;
-        foreach ($personImageVersions as $personImageVersion) {
-            $this->addPersonImageVersion($personImageVersion);
-        }
-
-        $this->collPersonImageVersions = $personImageVersions;
-        $this->collPersonImageVersionsPartial = false;
-
-        return $this;
-    }
-
-    /**
-     * Returns the number of related PersonImageVersion objects.
-     *
-     * @param      Criteria $criteria
-     * @param      boolean $distinct
-     * @param      ConnectionInterface $con
-     * @return int             Count of related PersonImageVersion objects.
-     * @throws PropelException
-     */
-    public function countPersonImageVersions(Criteria $criteria = null, $distinct = false, ConnectionInterface $con = null)
-    {
-        $partial = $this->collPersonImageVersionsPartial && !$this->isNew();
-        if (null === $this->collPersonImageVersions || null !== $criteria || $partial) {
-            if ($this->isNew() && null === $this->collPersonImageVersions) {
-                return 0;
-            }
-
-            if ($partial && !$criteria) {
-                return count($this->getPersonImageVersions());
-            }
-
-            $query = ChildPersonImageVersionQuery::create(null, $criteria);
-            if ($distinct) {
-                $query->distinct();
-            }
-
-            return $query
-                ->filterByPersonImage($this)
-                ->count($con);
-        }
-
-        return count($this->collPersonImageVersions);
-    }
-
-    /**
-     * Method called to associate a ChildPersonImageVersion object to this object
-     * through the ChildPersonImageVersion foreign key attribute.
-     *
-     * @param    ChildPersonImageVersion $l ChildPersonImageVersion
-     * @return   \Team\Model\PersonImage The current object (for fluent API support)
-     */
-    public function addPersonImageVersion(ChildPersonImageVersion $l)
-    {
-        if ($this->collPersonImageVersions === null) {
-            $this->initPersonImageVersions();
-            $this->collPersonImageVersionsPartial = true;
-        }
-
-        if (!in_array($l, $this->collPersonImageVersions->getArrayCopy(), true)) { // only add it if the **same** object is not already associated
-            $this->doAddPersonImageVersion($l);
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param PersonImageVersion $personImageVersion The personImageVersion object to add.
-     */
-    protected function doAddPersonImageVersion($personImageVersion)
-    {
-        $this->collPersonImageVersions[]= $personImageVersion;
-        $personImageVersion->setPersonImage($this);
-    }
-
-    /**
-     * @param  PersonImageVersion $personImageVersion The personImageVersion object to remove.
-     * @return ChildPersonImage The current object (for fluent API support)
-     */
-    public function removePersonImageVersion($personImageVersion)
-    {
-        if ($this->getPersonImageVersions()->contains($personImageVersion)) {
-            $this->collPersonImageVersions->remove($this->collPersonImageVersions->search($personImageVersion));
-            if (null === $this->personImageVersionsScheduledForDeletion) {
-                $this->personImageVersionsScheduledForDeletion = clone $this->collPersonImageVersions;
-                $this->personImageVersionsScheduledForDeletion->clear();
-            }
-            $this->personImageVersionsScheduledForDeletion[]= clone $personImageVersion;
-            $personImageVersion->setPersonImage(null);
-        }
-
-        return $this;
-    }
-
-    /**
      * Clears the current object and sets all attributes to their default values
      */
     public function clear()
@@ -2169,9 +1692,6 @@ abstract class PersonImage implements ActiveRecordInterface
         $this->position = null;
         $this->created_at = null;
         $this->updated_at = null;
-        $this->version = null;
-        $this->version_created_at = null;
-        $this->version_created_by = null;
         $this->alreadyInSave = false;
         $this->clearAllReferences();
         $this->applyDefaultValues();
@@ -2197,11 +1717,6 @@ abstract class PersonImage implements ActiveRecordInterface
                     $o->clearAllReferences($deep);
                 }
             }
-            if ($this->collPersonImageVersions) {
-                foreach ($this->collPersonImageVersions as $o) {
-                    $o->clearAllReferences($deep);
-                }
-            }
         } // if ($deep)
 
         // i18n behavior
@@ -2209,7 +1724,6 @@ abstract class PersonImage implements ActiveRecordInterface
         $this->currentTranslations = null;
 
         $this->collPersonImageI18ns = null;
-        $this->collPersonImageVersions = null;
         $this->aPerson = null;
     }
 
@@ -2432,313 +1946,6 @@ abstract class PersonImage implements ActiveRecordInterface
         return $this;
     }
 
-    // versionable behavior
-
-    /**
-     * Enforce a new Version of this object upon next save.
-     *
-     * @return \Team\Model\PersonImage
-     */
-    public function enforceVersioning()
-    {
-        $this->enforceVersion = true;
-
-        return $this;
-    }
-
-    /**
-     * Checks whether the current state must be recorded as a version
-     *
-     * @return  boolean
-     */
-    public function isVersioningNecessary($con = null)
-    {
-        if ($this->alreadyInSave) {
-            return false;
-        }
-
-        if ($this->enforceVersion) {
-            return true;
-        }
-
-        if (ChildPersonImageQuery::isVersioningEnabled() && ($this->isNew() || $this->isModified()) || $this->isDeleted()) {
-            return true;
-        }
-        if (null !== ($object = $this->getPerson($con)) && $object->isVersioningNecessary($con)) {
-            return true;
-        }
-
-
-        return false;
-    }
-
-    /**
-     * Creates a version of the current object and saves it.
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ChildPersonImageVersion A version object
-     */
-    public function addVersion($con = null)
-    {
-        $this->enforceVersion = false;
-
-        $version = new ChildPersonImageVersion();
-        $version->setId($this->getId());
-        $version->setFile($this->getFile());
-        $version->setPersonId($this->getPersonId());
-        $version->setVisible($this->getVisible());
-        $version->setPosition($this->getPosition());
-        $version->setCreatedAt($this->getCreatedAt());
-        $version->setUpdatedAt($this->getUpdatedAt());
-        $version->setVersion($this->getVersion());
-        $version->setVersionCreatedAt($this->getVersionCreatedAt());
-        $version->setVersionCreatedBy($this->getVersionCreatedBy());
-        $version->setPersonImage($this);
-        if (($related = $this->getPerson($con)) && $related->getVersion()) {
-            $version->setPersonIdVersion($related->getVersion());
-        }
-        $version->save($con);
-
-        return $version;
-    }
-
-    /**
-     * Sets the properties of the current object to the value they had at a specific version
-     *
-     * @param   integer $versionNumber The version number to read
-     * @param   ConnectionInterface $con The connection to use
-     *
-     * @return  ChildPersonImage The current object (for fluent API support)
-     */
-    public function toVersion($versionNumber, $con = null)
-    {
-        $version = $this->getOneVersion($versionNumber, $con);
-        if (!$version) {
-            throw new PropelException(sprintf('No ChildPersonImage object found with version %d', $version));
-        }
-        $this->populateFromVersion($version, $con);
-
-        return $this;
-    }
-
-    /**
-     * Sets the properties of the current object to the value they had at a specific version
-     *
-     * @param ChildPersonImageVersion $version The version object to use
-     * @param ConnectionInterface   $con the connection to use
-     * @param array                 $loadedObjects objects that been loaded in a chain of populateFromVersion calls on referrer or fk objects.
-     *
-     * @return ChildPersonImage The current object (for fluent API support)
-     */
-    public function populateFromVersion($version, $con = null, &$loadedObjects = array())
-    {
-        $loadedObjects['ChildPersonImage'][$version->getId()][$version->getVersion()] = $this;
-        $this->setId($version->getId());
-        $this->setFile($version->getFile());
-        $this->setPersonId($version->getPersonId());
-        $this->setVisible($version->getVisible());
-        $this->setPosition($version->getPosition());
-        $this->setCreatedAt($version->getCreatedAt());
-        $this->setUpdatedAt($version->getUpdatedAt());
-        $this->setVersion($version->getVersion());
-        $this->setVersionCreatedAt($version->getVersionCreatedAt());
-        $this->setVersionCreatedBy($version->getVersionCreatedBy());
-        if ($fkValue = $version->getPersonId()) {
-            if (isset($loadedObjects['ChildPerson']) && isset($loadedObjects['ChildPerson'][$fkValue]) && isset($loadedObjects['ChildPerson'][$fkValue][$version->getPersonIdVersion()])) {
-                $related = $loadedObjects['ChildPerson'][$fkValue][$version->getPersonIdVersion()];
-            } else {
-                $related = new ChildPerson();
-                $relatedVersion = ChildPersonVersionQuery::create()
-                    ->filterById($fkValue)
-                    ->filterByVersion($version->getPersonIdVersion())
-                    ->findOne($con);
-                $related->populateFromVersion($relatedVersion, $con, $loadedObjects);
-                $related->setNew(false);
-            }
-            $this->setPerson($related);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Gets the latest persisted version number for the current object
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  integer
-     */
-    public function getLastVersionNumber($con = null)
-    {
-        $v = ChildPersonImageVersionQuery::create()
-            ->filterByPersonImage($this)
-            ->orderByVersion('desc')
-            ->findOne($con);
-        if (!$v) {
-            return 0;
-        }
-
-        return $v->getVersion();
-    }
-
-    /**
-     * Checks whether the current object is the latest one
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  Boolean
-     */
-    public function isLastVersion($con = null)
-    {
-        return $this->getLastVersionNumber($con) == $this->getVersion();
-    }
-
-    /**
-     * Retrieves a version object for this entity and a version number
-     *
-     * @param   integer $versionNumber The version number to read
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ChildPersonImageVersion A version object
-     */
-    public function getOneVersion($versionNumber, $con = null)
-    {
-        return ChildPersonImageVersionQuery::create()
-            ->filterByPersonImage($this)
-            ->filterByVersion($versionNumber)
-            ->findOne($con);
-    }
-
-    /**
-     * Gets all the versions of this object, in incremental order
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ObjectCollection A list of ChildPersonImageVersion objects
-     */
-    public function getAllVersions($con = null)
-    {
-        $criteria = new Criteria();
-        $criteria->addAscendingOrderByColumn(PersonImageVersionTableMap::VERSION);
-
-        return $this->getPersonImageVersions($criteria, $con);
-    }
-
-    /**
-     * Compares the current object with another of its version.
-     * <code>
-     * print_r($book->compareVersion(1));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   integer             $versionNumber
-     * @param   string              $keys Main key used for the result diff (versions|columns)
-     * @param   ConnectionInterface $con the connection to use
-     * @param   array               $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    public function compareVersion($versionNumber, $keys = 'columns', $con = null, $ignoredColumns = array())
-    {
-        $fromVersion = $this->toArray();
-        $toVersion = $this->getOneVersion($versionNumber, $con)->toArray();
-
-        return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
-    }
-
-    /**
-     * Compares two versions of the current object.
-     * <code>
-     * print_r($book->compareVersions(1, 2));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   integer             $fromVersionNumber
-     * @param   integer             $toVersionNumber
-     * @param   string              $keys Main key used for the result diff (versions|columns)
-     * @param   ConnectionInterface $con the connection to use
-     * @param   array               $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    public function compareVersions($fromVersionNumber, $toVersionNumber, $keys = 'columns', $con = null, $ignoredColumns = array())
-    {
-        $fromVersion = $this->getOneVersion($fromVersionNumber, $con)->toArray();
-        $toVersion = $this->getOneVersion($toVersionNumber, $con)->toArray();
-
-        return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
-    }
-
-    /**
-     * Computes the diff between two versions.
-     * <code>
-     * print_r($book->computeDiff(1, 2));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   array     $fromVersion     An array representing the original version.
-     * @param   array     $toVersion       An array representing the destination version.
-     * @param   string    $keys            Main key used for the result diff (versions|columns).
-     * @param   array     $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    protected function computeDiff($fromVersion, $toVersion, $keys = 'columns', $ignoredColumns = array())
-    {
-        $fromVersionNumber = $fromVersion['Version'];
-        $toVersionNumber = $toVersion['Version'];
-        $ignoredColumns = array_merge(array(
-            'Version',
-            'VersionCreatedAt',
-            'VersionCreatedBy',
-        ), $ignoredColumns);
-        $diff = array();
-        foreach ($fromVersion as $key => $value) {
-            if (in_array($key, $ignoredColumns)) {
-                continue;
-            }
-            if ($toVersion[$key] != $value) {
-                switch ($keys) {
-                    case 'versions':
-                        $diff[$fromVersionNumber][$key] = $value;
-                        $diff[$toVersionNumber][$key] = $toVersion[$key];
-                        break;
-                    default:
-                        $diff[$key] = array(
-                            $fromVersionNumber => $value,
-                            $toVersionNumber => $toVersion[$key],
-                        );
-                        break;
-                }
-            }
-        }
-
-        return $diff;
-    }
-    /**
-     * retrieve the last $number versions.
-     *
-     * @param Integer $number the number of record to return.
-     * @return PropelCollection|array \Team\Model\PersonImageVersion[] List of \Team\Model\PersonImageVersion objects
-     */
-    public function getLastVersions($number = 10, $criteria = null, $con = null)
-    {
-        $criteria = ChildPersonImageVersionQuery::create(null, $criteria);
-        $criteria->addDescendingOrderByColumn(PersonImageVersionTableMap::VERSION);
-        $criteria->limit($number);
-
-        return $this->getPersonImageVersions($criteria, $con);
-    }
     /**
      * Code to be run before persisting the object
      * @param  ConnectionInterface $con

--- a/Model/Base/PersonImageQuery.php
+++ b/Model/Base/PersonImageQuery.php
@@ -29,9 +29,6 @@ use Team\Model\Map\PersonImageTableMap;
  * @method     ChildPersonImageQuery orderByPosition($order = Criteria::ASC) Order by the position column
  * @method     ChildPersonImageQuery orderByCreatedAt($order = Criteria::ASC) Order by the created_at column
  * @method     ChildPersonImageQuery orderByUpdatedAt($order = Criteria::ASC) Order by the updated_at column
- * @method     ChildPersonImageQuery orderByVersion($order = Criteria::ASC) Order by the version column
- * @method     ChildPersonImageQuery orderByVersionCreatedAt($order = Criteria::ASC) Order by the version_created_at column
- * @method     ChildPersonImageQuery orderByVersionCreatedBy($order = Criteria::ASC) Order by the version_created_by column
  *
  * @method     ChildPersonImageQuery groupById() Group by the id column
  * @method     ChildPersonImageQuery groupByFile() Group by the file column
@@ -40,9 +37,6 @@ use Team\Model\Map\PersonImageTableMap;
  * @method     ChildPersonImageQuery groupByPosition() Group by the position column
  * @method     ChildPersonImageQuery groupByCreatedAt() Group by the created_at column
  * @method     ChildPersonImageQuery groupByUpdatedAt() Group by the updated_at column
- * @method     ChildPersonImageQuery groupByVersion() Group by the version column
- * @method     ChildPersonImageQuery groupByVersionCreatedAt() Group by the version_created_at column
- * @method     ChildPersonImageQuery groupByVersionCreatedBy() Group by the version_created_by column
  *
  * @method     ChildPersonImageQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
  * @method     ChildPersonImageQuery rightJoin($relation) Adds a RIGHT JOIN clause to the query
@@ -56,10 +50,6 @@ use Team\Model\Map\PersonImageTableMap;
  * @method     ChildPersonImageQuery rightJoinPersonImageI18n($relationAlias = null) Adds a RIGHT JOIN clause to the query using the PersonImageI18n relation
  * @method     ChildPersonImageQuery innerJoinPersonImageI18n($relationAlias = null) Adds a INNER JOIN clause to the query using the PersonImageI18n relation
  *
- * @method     ChildPersonImageQuery leftJoinPersonImageVersion($relationAlias = null) Adds a LEFT JOIN clause to the query using the PersonImageVersion relation
- * @method     ChildPersonImageQuery rightJoinPersonImageVersion($relationAlias = null) Adds a RIGHT JOIN clause to the query using the PersonImageVersion relation
- * @method     ChildPersonImageQuery innerJoinPersonImageVersion($relationAlias = null) Adds a INNER JOIN clause to the query using the PersonImageVersion relation
- *
  * @method     ChildPersonImage findOne(ConnectionInterface $con = null) Return the first ChildPersonImage matching the query
  * @method     ChildPersonImage findOneOrCreate(ConnectionInterface $con = null) Return the first ChildPersonImage matching the query, or a new ChildPersonImage object populated from the query conditions when no match is found
  *
@@ -70,9 +60,6 @@ use Team\Model\Map\PersonImageTableMap;
  * @method     ChildPersonImage findOneByPosition(int $position) Return the first ChildPersonImage filtered by the position column
  * @method     ChildPersonImage findOneByCreatedAt(string $created_at) Return the first ChildPersonImage filtered by the created_at column
  * @method     ChildPersonImage findOneByUpdatedAt(string $updated_at) Return the first ChildPersonImage filtered by the updated_at column
- * @method     ChildPersonImage findOneByVersion(int $version) Return the first ChildPersonImage filtered by the version column
- * @method     ChildPersonImage findOneByVersionCreatedAt(string $version_created_at) Return the first ChildPersonImage filtered by the version_created_at column
- * @method     ChildPersonImage findOneByVersionCreatedBy(string $version_created_by) Return the first ChildPersonImage filtered by the version_created_by column
  *
  * @method     array findById(int $id) Return ChildPersonImage objects filtered by the id column
  * @method     array findByFile(string $file) Return ChildPersonImage objects filtered by the file column
@@ -81,20 +68,10 @@ use Team\Model\Map\PersonImageTableMap;
  * @method     array findByPosition(int $position) Return ChildPersonImage objects filtered by the position column
  * @method     array findByCreatedAt(string $created_at) Return ChildPersonImage objects filtered by the created_at column
  * @method     array findByUpdatedAt(string $updated_at) Return ChildPersonImage objects filtered by the updated_at column
- * @method     array findByVersion(int $version) Return ChildPersonImage objects filtered by the version column
- * @method     array findByVersionCreatedAt(string $version_created_at) Return ChildPersonImage objects filtered by the version_created_at column
- * @method     array findByVersionCreatedBy(string $version_created_by) Return ChildPersonImage objects filtered by the version_created_by column
  *
  */
 abstract class PersonImageQuery extends ModelCriteria
 {
-
-    // versionable behavior
-
-    /**
-     * Whether the versioning is enabled
-     */
-    static $isVersioningEnabled = true;
 
     /**
      * Initializes internal state of \Team\Model\Base\PersonImageQuery object.
@@ -179,7 +156,7 @@ abstract class PersonImageQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT ID, FILE, PERSON_ID, VISIBLE, POSITION, CREATED_AT, UPDATED_AT, VERSION, VERSION_CREATED_AT, VERSION_CREATED_BY FROM person_image WHERE ID = :p0';
+        $sql = 'SELECT ID, FILE, PERSON_ID, VISIBLE, POSITION, CREATED_AT, UPDATED_AT FROM person_image WHERE ID = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -550,119 +527,6 @@ abstract class PersonImageQuery extends ModelCriteria
     }
 
     /**
-     * Filter the query on the version column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersion(1234); // WHERE version = 1234
-     * $query->filterByVersion(array(12, 34)); // WHERE version IN (12, 34)
-     * $query->filterByVersion(array('min' => 12)); // WHERE version > 12
-     * </code>
-     *
-     * @param     mixed $version The value to use as filter.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonImageQuery The current query, for fluid interface
-     */
-    public function filterByVersion($version = null, $comparison = null)
-    {
-        if (is_array($version)) {
-            $useMinMax = false;
-            if (isset($version['min'])) {
-                $this->addUsingAlias(PersonImageTableMap::VERSION, $version['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($version['max'])) {
-                $this->addUsingAlias(PersonImageTableMap::VERSION, $version['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(PersonImageTableMap::VERSION, $version, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_at column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedAt('2011-03-14'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt('now'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt(array('max' => 'yesterday')); // WHERE version_created_at > '2011-03-13'
-     * </code>
-     *
-     * @param     mixed $versionCreatedAt The value to use as filter.
-     *              Values can be integers (unix timestamps), DateTime objects, or strings.
-     *              Empty strings are treated as NULL.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonImageQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedAt($versionCreatedAt = null, $comparison = null)
-    {
-        if (is_array($versionCreatedAt)) {
-            $useMinMax = false;
-            if (isset($versionCreatedAt['min'])) {
-                $this->addUsingAlias(PersonImageTableMap::VERSION_CREATED_AT, $versionCreatedAt['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($versionCreatedAt['max'])) {
-                $this->addUsingAlias(PersonImageTableMap::VERSION_CREATED_AT, $versionCreatedAt['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(PersonImageTableMap::VERSION_CREATED_AT, $versionCreatedAt, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_by column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedBy('fooValue');   // WHERE version_created_by = 'fooValue'
-     * $query->filterByVersionCreatedBy('%fooValue%'); // WHERE version_created_by LIKE '%fooValue%'
-     * </code>
-     *
-     * @param     string $versionCreatedBy The value to use as filter.
-     *              Accepts wildcards (* and % trigger a LIKE)
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonImageQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedBy($versionCreatedBy = null, $comparison = null)
-    {
-        if (null === $comparison) {
-            if (is_array($versionCreatedBy)) {
-                $comparison = Criteria::IN;
-            } elseif (preg_match('/[\%\*]/', $versionCreatedBy)) {
-                $versionCreatedBy = str_replace('*', '%', $versionCreatedBy);
-                $comparison = Criteria::LIKE;
-            }
-        }
-
-        return $this->addUsingAlias(PersonImageTableMap::VERSION_CREATED_BY, $versionCreatedBy, $comparison);
-    }
-
-    /**
      * Filter the query by a related \Team\Model\Person object
      *
      * @param \Team\Model\Person|ObjectCollection $person The related object(s) to use as filter
@@ -808,79 +672,6 @@ abstract class PersonImageQuery extends ModelCriteria
         return $this
             ->joinPersonImageI18n($relationAlias, $joinType)
             ->useQuery($relationAlias ? $relationAlias : 'PersonImageI18n', '\Team\Model\PersonImageI18nQuery');
-    }
-
-    /**
-     * Filter the query by a related \Team\Model\PersonImageVersion object
-     *
-     * @param \Team\Model\PersonImageVersion|ObjectCollection $personImageVersion  the related object to use as filter
-     * @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonImageQuery The current query, for fluid interface
-     */
-    public function filterByPersonImageVersion($personImageVersion, $comparison = null)
-    {
-        if ($personImageVersion instanceof \Team\Model\PersonImageVersion) {
-            return $this
-                ->addUsingAlias(PersonImageTableMap::ID, $personImageVersion->getId(), $comparison);
-        } elseif ($personImageVersion instanceof ObjectCollection) {
-            return $this
-                ->usePersonImageVersionQuery()
-                ->filterByPrimaryKeys($personImageVersion->getPrimaryKeys())
-                ->endUse();
-        } else {
-            throw new PropelException('filterByPersonImageVersion() only accepts arguments of type \Team\Model\PersonImageVersion or Collection');
-        }
-    }
-
-    /**
-     * Adds a JOIN clause to the query using the PersonImageVersion relation
-     *
-     * @param     string $relationAlias optional alias for the relation
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return ChildPersonImageQuery The current query, for fluid interface
-     */
-    public function joinPersonImageVersion($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        $tableMap = $this->getTableMap();
-        $relationMap = $tableMap->getRelation('PersonImageVersion');
-
-        // create a ModelJoin object for this join
-        $join = new ModelJoin();
-        $join->setJoinType($joinType);
-        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
-        if ($previousJoin = $this->getPreviousJoin()) {
-            $join->setPreviousJoin($previousJoin);
-        }
-
-        // add the ModelJoin to the current object
-        if ($relationAlias) {
-            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
-            $this->addJoinObject($join, $relationAlias);
-        } else {
-            $this->addJoinObject($join, 'PersonImageVersion');
-        }
-
-        return $this;
-    }
-
-    /**
-     * Use the PersonImageVersion relation PersonImageVersion object
-     *
-     * @see useQuery()
-     *
-     * @param     string $relationAlias optional alias for the relation,
-     *                                   to be used as main alias in the secondary query
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return   \Team\Model\PersonImageVersionQuery A secondary query class using the current class as primary query
-     */
-    public function usePersonImageVersionQuery($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        return $this
-            ->joinPersonImageVersion($relationAlias, $joinType)
-            ->useQuery($relationAlias ? $relationAlias : 'PersonImageVersion', '\Team\Model\PersonImageVersionQuery');
     }
 
     /**
@@ -1095,34 +886,6 @@ abstract class PersonImageQuery extends ModelCriteria
         return $this
             ->joinI18n($locale, $relationAlias, $joinType)
             ->useQuery($relationAlias ? $relationAlias : 'PersonImageI18n', '\Team\Model\PersonImageI18nQuery');
-    }
-
-    // versionable behavior
-
-    /**
-     * Checks whether versioning is enabled
-     *
-     * @return boolean
-     */
-    static public function isVersioningEnabled()
-    {
-        return self::$isVersioningEnabled;
-    }
-
-    /**
-     * Enables versioning
-     */
-    static public function enableVersioning()
-    {
-        self::$isVersioningEnabled = true;
-    }
-
-    /**
-     * Disables versioning
-     */
-    static public function disableVersioning()
-    {
-        self::$isVersioningEnabled = false;
     }
 
 } // PersonImageQuery

--- a/Model/Base/PersonQuery.php
+++ b/Model/Base/PersonQuery.php
@@ -27,18 +27,12 @@ use Team\Model\Map\PersonTableMap;
  * @method     ChildPersonQuery orderByLastName($order = Criteria::ASC) Order by the last_name column
  * @method     ChildPersonQuery orderByCreatedAt($order = Criteria::ASC) Order by the created_at column
  * @method     ChildPersonQuery orderByUpdatedAt($order = Criteria::ASC) Order by the updated_at column
- * @method     ChildPersonQuery orderByVersion($order = Criteria::ASC) Order by the version column
- * @method     ChildPersonQuery orderByVersionCreatedAt($order = Criteria::ASC) Order by the version_created_at column
- * @method     ChildPersonQuery orderByVersionCreatedBy($order = Criteria::ASC) Order by the version_created_by column
  *
  * @method     ChildPersonQuery groupById() Group by the id column
  * @method     ChildPersonQuery groupByFirstName() Group by the first_name column
  * @method     ChildPersonQuery groupByLastName() Group by the last_name column
  * @method     ChildPersonQuery groupByCreatedAt() Group by the created_at column
  * @method     ChildPersonQuery groupByUpdatedAt() Group by the updated_at column
- * @method     ChildPersonQuery groupByVersion() Group by the version column
- * @method     ChildPersonQuery groupByVersionCreatedAt() Group by the version_created_at column
- * @method     ChildPersonQuery groupByVersionCreatedBy() Group by the version_created_by column
  *
  * @method     ChildPersonQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
  * @method     ChildPersonQuery rightJoin($relation) Adds a RIGHT JOIN clause to the query
@@ -60,10 +54,6 @@ use Team\Model\Map\PersonTableMap;
  * @method     ChildPersonQuery rightJoinPersonI18n($relationAlias = null) Adds a RIGHT JOIN clause to the query using the PersonI18n relation
  * @method     ChildPersonQuery innerJoinPersonI18n($relationAlias = null) Adds a INNER JOIN clause to the query using the PersonI18n relation
  *
- * @method     ChildPersonQuery leftJoinPersonVersion($relationAlias = null) Adds a LEFT JOIN clause to the query using the PersonVersion relation
- * @method     ChildPersonQuery rightJoinPersonVersion($relationAlias = null) Adds a RIGHT JOIN clause to the query using the PersonVersion relation
- * @method     ChildPersonQuery innerJoinPersonVersion($relationAlias = null) Adds a INNER JOIN clause to the query using the PersonVersion relation
- *
  * @method     ChildPerson findOne(ConnectionInterface $con = null) Return the first ChildPerson matching the query
  * @method     ChildPerson findOneOrCreate(ConnectionInterface $con = null) Return the first ChildPerson matching the query, or a new ChildPerson object populated from the query conditions when no match is found
  *
@@ -72,29 +62,16 @@ use Team\Model\Map\PersonTableMap;
  * @method     ChildPerson findOneByLastName(string $last_name) Return the first ChildPerson filtered by the last_name column
  * @method     ChildPerson findOneByCreatedAt(string $created_at) Return the first ChildPerson filtered by the created_at column
  * @method     ChildPerson findOneByUpdatedAt(string $updated_at) Return the first ChildPerson filtered by the updated_at column
- * @method     ChildPerson findOneByVersion(int $version) Return the first ChildPerson filtered by the version column
- * @method     ChildPerson findOneByVersionCreatedAt(string $version_created_at) Return the first ChildPerson filtered by the version_created_at column
- * @method     ChildPerson findOneByVersionCreatedBy(string $version_created_by) Return the first ChildPerson filtered by the version_created_by column
  *
  * @method     array findById(int $id) Return ChildPerson objects filtered by the id column
  * @method     array findByFirstName(string $first_name) Return ChildPerson objects filtered by the first_name column
  * @method     array findByLastName(string $last_name) Return ChildPerson objects filtered by the last_name column
  * @method     array findByCreatedAt(string $created_at) Return ChildPerson objects filtered by the created_at column
  * @method     array findByUpdatedAt(string $updated_at) Return ChildPerson objects filtered by the updated_at column
- * @method     array findByVersion(int $version) Return ChildPerson objects filtered by the version column
- * @method     array findByVersionCreatedAt(string $version_created_at) Return ChildPerson objects filtered by the version_created_at column
- * @method     array findByVersionCreatedBy(string $version_created_by) Return ChildPerson objects filtered by the version_created_by column
  *
  */
 abstract class PersonQuery extends ModelCriteria
 {
-
-    // versionable behavior
-
-    /**
-     * Whether the versioning is enabled
-     */
-    static $isVersioningEnabled = true;
 
     /**
      * Initializes internal state of \Team\Model\Base\PersonQuery object.
@@ -179,7 +156,7 @@ abstract class PersonQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT ID, FIRST_NAME, LAST_NAME, CREATED_AT, UPDATED_AT, VERSION, VERSION_CREATED_AT, VERSION_CREATED_BY FROM person WHERE ID = :p0';
+        $sql = 'SELECT ID, FIRST_NAME, LAST_NAME, CREATED_AT, UPDATED_AT FROM person WHERE ID = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -451,119 +428,6 @@ abstract class PersonQuery extends ModelCriteria
         }
 
         return $this->addUsingAlias(PersonTableMap::UPDATED_AT, $updatedAt, $comparison);
-    }
-
-    /**
-     * Filter the query on the version column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersion(1234); // WHERE version = 1234
-     * $query->filterByVersion(array(12, 34)); // WHERE version IN (12, 34)
-     * $query->filterByVersion(array('min' => 12)); // WHERE version > 12
-     * </code>
-     *
-     * @param     mixed $version The value to use as filter.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonQuery The current query, for fluid interface
-     */
-    public function filterByVersion($version = null, $comparison = null)
-    {
-        if (is_array($version)) {
-            $useMinMax = false;
-            if (isset($version['min'])) {
-                $this->addUsingAlias(PersonTableMap::VERSION, $version['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($version['max'])) {
-                $this->addUsingAlias(PersonTableMap::VERSION, $version['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(PersonTableMap::VERSION, $version, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_at column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedAt('2011-03-14'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt('now'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt(array('max' => 'yesterday')); // WHERE version_created_at > '2011-03-13'
-     * </code>
-     *
-     * @param     mixed $versionCreatedAt The value to use as filter.
-     *              Values can be integers (unix timestamps), DateTime objects, or strings.
-     *              Empty strings are treated as NULL.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedAt($versionCreatedAt = null, $comparison = null)
-    {
-        if (is_array($versionCreatedAt)) {
-            $useMinMax = false;
-            if (isset($versionCreatedAt['min'])) {
-                $this->addUsingAlias(PersonTableMap::VERSION_CREATED_AT, $versionCreatedAt['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($versionCreatedAt['max'])) {
-                $this->addUsingAlias(PersonTableMap::VERSION_CREATED_AT, $versionCreatedAt['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(PersonTableMap::VERSION_CREATED_AT, $versionCreatedAt, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_by column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedBy('fooValue');   // WHERE version_created_by = 'fooValue'
-     * $query->filterByVersionCreatedBy('%fooValue%'); // WHERE version_created_by LIKE '%fooValue%'
-     * </code>
-     *
-     * @param     string $versionCreatedBy The value to use as filter.
-     *              Accepts wildcards (* and % trigger a LIKE)
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedBy($versionCreatedBy = null, $comparison = null)
-    {
-        if (null === $comparison) {
-            if (is_array($versionCreatedBy)) {
-                $comparison = Criteria::IN;
-            } elseif (preg_match('/[\%\*]/', $versionCreatedBy)) {
-                $versionCreatedBy = str_replace('*', '%', $versionCreatedBy);
-                $comparison = Criteria::LIKE;
-            }
-        }
-
-        return $this->addUsingAlias(PersonTableMap::VERSION_CREATED_BY, $versionCreatedBy, $comparison);
     }
 
     /**
@@ -859,79 +723,6 @@ abstract class PersonQuery extends ModelCriteria
     }
 
     /**
-     * Filter the query by a related \Team\Model\PersonVersion object
-     *
-     * @param \Team\Model\PersonVersion|ObjectCollection $personVersion  the related object to use as filter
-     * @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonQuery The current query, for fluid interface
-     */
-    public function filterByPersonVersion($personVersion, $comparison = null)
-    {
-        if ($personVersion instanceof \Team\Model\PersonVersion) {
-            return $this
-                ->addUsingAlias(PersonTableMap::ID, $personVersion->getId(), $comparison);
-        } elseif ($personVersion instanceof ObjectCollection) {
-            return $this
-                ->usePersonVersionQuery()
-                ->filterByPrimaryKeys($personVersion->getPrimaryKeys())
-                ->endUse();
-        } else {
-            throw new PropelException('filterByPersonVersion() only accepts arguments of type \Team\Model\PersonVersion or Collection');
-        }
-    }
-
-    /**
-     * Adds a JOIN clause to the query using the PersonVersion relation
-     *
-     * @param     string $relationAlias optional alias for the relation
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return ChildPersonQuery The current query, for fluid interface
-     */
-    public function joinPersonVersion($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        $tableMap = $this->getTableMap();
-        $relationMap = $tableMap->getRelation('PersonVersion');
-
-        // create a ModelJoin object for this join
-        $join = new ModelJoin();
-        $join->setJoinType($joinType);
-        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
-        if ($previousJoin = $this->getPreviousJoin()) {
-            $join->setPreviousJoin($previousJoin);
-        }
-
-        // add the ModelJoin to the current object
-        if ($relationAlias) {
-            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
-            $this->addJoinObject($join, $relationAlias);
-        } else {
-            $this->addJoinObject($join, 'PersonVersion');
-        }
-
-        return $this;
-    }
-
-    /**
-     * Use the PersonVersion relation PersonVersion object
-     *
-     * @see useQuery()
-     *
-     * @param     string $relationAlias optional alias for the relation,
-     *                                   to be used as main alias in the secondary query
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return   \Team\Model\PersonVersionQuery A secondary query class using the current class as primary query
-     */
-    public function usePersonVersionQuery($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        return $this
-            ->joinPersonVersion($relationAlias, $joinType)
-            ->useQuery($relationAlias ? $relationAlias : 'PersonVersion', '\Team\Model\PersonVersionQuery');
-    }
-
-    /**
      * Exclude object from result
      *
      * @param   ChildPerson $person Object to remove from the list of results
@@ -1143,34 +934,6 @@ abstract class PersonQuery extends ModelCriteria
         return $this
             ->joinI18n($locale, $relationAlias, $joinType)
             ->useQuery($relationAlias ? $relationAlias : 'PersonI18n', '\Team\Model\PersonI18nQuery');
-    }
-
-    // versionable behavior
-
-    /**
-     * Checks whether versioning is enabled
-     *
-     * @return boolean
-     */
-    static public function isVersioningEnabled()
-    {
-        return self::$isVersioningEnabled;
-    }
-
-    /**
-     * Enables versioning
-     */
-    static public function enableVersioning()
-    {
-        self::$isVersioningEnabled = true;
-    }
-
-    /**
-     * Disables versioning
-     */
-    static public function disableVersioning()
-    {
-        self::$isVersioningEnabled = false;
     }
 
 } // PersonQuery

--- a/Model/Base/PersonTeamLinkQuery.php
+++ b/Model/Base/PersonTeamLinkQuery.php
@@ -26,18 +26,12 @@ use Team\Model\Map\PersonTeamLinkTableMap;
  * @method     ChildPersonTeamLinkQuery orderByTeamId($order = Criteria::ASC) Order by the team_id column
  * @method     ChildPersonTeamLinkQuery orderByCreatedAt($order = Criteria::ASC) Order by the created_at column
  * @method     ChildPersonTeamLinkQuery orderByUpdatedAt($order = Criteria::ASC) Order by the updated_at column
- * @method     ChildPersonTeamLinkQuery orderByVersion($order = Criteria::ASC) Order by the version column
- * @method     ChildPersonTeamLinkQuery orderByVersionCreatedAt($order = Criteria::ASC) Order by the version_created_at column
- * @method     ChildPersonTeamLinkQuery orderByVersionCreatedBy($order = Criteria::ASC) Order by the version_created_by column
  *
  * @method     ChildPersonTeamLinkQuery groupById() Group by the id column
  * @method     ChildPersonTeamLinkQuery groupByPersonId() Group by the person_id column
  * @method     ChildPersonTeamLinkQuery groupByTeamId() Group by the team_id column
  * @method     ChildPersonTeamLinkQuery groupByCreatedAt() Group by the created_at column
  * @method     ChildPersonTeamLinkQuery groupByUpdatedAt() Group by the updated_at column
- * @method     ChildPersonTeamLinkQuery groupByVersion() Group by the version column
- * @method     ChildPersonTeamLinkQuery groupByVersionCreatedAt() Group by the version_created_at column
- * @method     ChildPersonTeamLinkQuery groupByVersionCreatedBy() Group by the version_created_by column
  *
  * @method     ChildPersonTeamLinkQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
  * @method     ChildPersonTeamLinkQuery rightJoin($relation) Adds a RIGHT JOIN clause to the query
@@ -51,10 +45,6 @@ use Team\Model\Map\PersonTeamLinkTableMap;
  * @method     ChildPersonTeamLinkQuery rightJoinTeam($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Team relation
  * @method     ChildPersonTeamLinkQuery innerJoinTeam($relationAlias = null) Adds a INNER JOIN clause to the query using the Team relation
  *
- * @method     ChildPersonTeamLinkQuery leftJoinPersonTeamLinkVersion($relationAlias = null) Adds a LEFT JOIN clause to the query using the PersonTeamLinkVersion relation
- * @method     ChildPersonTeamLinkQuery rightJoinPersonTeamLinkVersion($relationAlias = null) Adds a RIGHT JOIN clause to the query using the PersonTeamLinkVersion relation
- * @method     ChildPersonTeamLinkQuery innerJoinPersonTeamLinkVersion($relationAlias = null) Adds a INNER JOIN clause to the query using the PersonTeamLinkVersion relation
- *
  * @method     ChildPersonTeamLink findOne(ConnectionInterface $con = null) Return the first ChildPersonTeamLink matching the query
  * @method     ChildPersonTeamLink findOneOrCreate(ConnectionInterface $con = null) Return the first ChildPersonTeamLink matching the query, or a new ChildPersonTeamLink object populated from the query conditions when no match is found
  *
@@ -63,29 +53,16 @@ use Team\Model\Map\PersonTeamLinkTableMap;
  * @method     ChildPersonTeamLink findOneByTeamId(int $team_id) Return the first ChildPersonTeamLink filtered by the team_id column
  * @method     ChildPersonTeamLink findOneByCreatedAt(string $created_at) Return the first ChildPersonTeamLink filtered by the created_at column
  * @method     ChildPersonTeamLink findOneByUpdatedAt(string $updated_at) Return the first ChildPersonTeamLink filtered by the updated_at column
- * @method     ChildPersonTeamLink findOneByVersion(int $version) Return the first ChildPersonTeamLink filtered by the version column
- * @method     ChildPersonTeamLink findOneByVersionCreatedAt(string $version_created_at) Return the first ChildPersonTeamLink filtered by the version_created_at column
- * @method     ChildPersonTeamLink findOneByVersionCreatedBy(string $version_created_by) Return the first ChildPersonTeamLink filtered by the version_created_by column
  *
  * @method     array findById(int $id) Return ChildPersonTeamLink objects filtered by the id column
  * @method     array findByPersonId(int $person_id) Return ChildPersonTeamLink objects filtered by the person_id column
  * @method     array findByTeamId(int $team_id) Return ChildPersonTeamLink objects filtered by the team_id column
  * @method     array findByCreatedAt(string $created_at) Return ChildPersonTeamLink objects filtered by the created_at column
  * @method     array findByUpdatedAt(string $updated_at) Return ChildPersonTeamLink objects filtered by the updated_at column
- * @method     array findByVersion(int $version) Return ChildPersonTeamLink objects filtered by the version column
- * @method     array findByVersionCreatedAt(string $version_created_at) Return ChildPersonTeamLink objects filtered by the version_created_at column
- * @method     array findByVersionCreatedBy(string $version_created_by) Return ChildPersonTeamLink objects filtered by the version_created_by column
  *
  */
 abstract class PersonTeamLinkQuery extends ModelCriteria
 {
-
-    // versionable behavior
-
-    /**
-     * Whether the versioning is enabled
-     */
-    static $isVersioningEnabled = true;
 
     /**
      * Initializes internal state of \Team\Model\Base\PersonTeamLinkQuery object.
@@ -170,7 +147,7 @@ abstract class PersonTeamLinkQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT ID, PERSON_ID, TEAM_ID, CREATED_AT, UPDATED_AT, VERSION, VERSION_CREATED_AT, VERSION_CREATED_BY FROM person_team_link WHERE ID = :p0';
+        $sql = 'SELECT ID, PERSON_ID, TEAM_ID, CREATED_AT, UPDATED_AT FROM person_team_link WHERE ID = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -473,119 +450,6 @@ abstract class PersonTeamLinkQuery extends ModelCriteria
     }
 
     /**
-     * Filter the query on the version column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersion(1234); // WHERE version = 1234
-     * $query->filterByVersion(array(12, 34)); // WHERE version IN (12, 34)
-     * $query->filterByVersion(array('min' => 12)); // WHERE version > 12
-     * </code>
-     *
-     * @param     mixed $version The value to use as filter.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonTeamLinkQuery The current query, for fluid interface
-     */
-    public function filterByVersion($version = null, $comparison = null)
-    {
-        if (is_array($version)) {
-            $useMinMax = false;
-            if (isset($version['min'])) {
-                $this->addUsingAlias(PersonTeamLinkTableMap::VERSION, $version['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($version['max'])) {
-                $this->addUsingAlias(PersonTeamLinkTableMap::VERSION, $version['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(PersonTeamLinkTableMap::VERSION, $version, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_at column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedAt('2011-03-14'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt('now'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt(array('max' => 'yesterday')); // WHERE version_created_at > '2011-03-13'
-     * </code>
-     *
-     * @param     mixed $versionCreatedAt The value to use as filter.
-     *              Values can be integers (unix timestamps), DateTime objects, or strings.
-     *              Empty strings are treated as NULL.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonTeamLinkQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedAt($versionCreatedAt = null, $comparison = null)
-    {
-        if (is_array($versionCreatedAt)) {
-            $useMinMax = false;
-            if (isset($versionCreatedAt['min'])) {
-                $this->addUsingAlias(PersonTeamLinkTableMap::VERSION_CREATED_AT, $versionCreatedAt['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($versionCreatedAt['max'])) {
-                $this->addUsingAlias(PersonTeamLinkTableMap::VERSION_CREATED_AT, $versionCreatedAt['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(PersonTeamLinkTableMap::VERSION_CREATED_AT, $versionCreatedAt, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_by column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedBy('fooValue');   // WHERE version_created_by = 'fooValue'
-     * $query->filterByVersionCreatedBy('%fooValue%'); // WHERE version_created_by LIKE '%fooValue%'
-     * </code>
-     *
-     * @param     string $versionCreatedBy The value to use as filter.
-     *              Accepts wildcards (* and % trigger a LIKE)
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonTeamLinkQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedBy($versionCreatedBy = null, $comparison = null)
-    {
-        if (null === $comparison) {
-            if (is_array($versionCreatedBy)) {
-                $comparison = Criteria::IN;
-            } elseif (preg_match('/[\%\*]/', $versionCreatedBy)) {
-                $versionCreatedBy = str_replace('*', '%', $versionCreatedBy);
-                $comparison = Criteria::LIKE;
-            }
-        }
-
-        return $this->addUsingAlias(PersonTeamLinkTableMap::VERSION_CREATED_BY, $versionCreatedBy, $comparison);
-    }
-
-    /**
      * Filter the query by a related \Team\Model\Person object
      *
      * @param \Team\Model\Person|ObjectCollection $person The related object(s) to use as filter
@@ -733,79 +597,6 @@ abstract class PersonTeamLinkQuery extends ModelCriteria
         return $this
             ->joinTeam($relationAlias, $joinType)
             ->useQuery($relationAlias ? $relationAlias : 'Team', '\Team\Model\TeamQuery');
-    }
-
-    /**
-     * Filter the query by a related \Team\Model\PersonTeamLinkVersion object
-     *
-     * @param \Team\Model\PersonTeamLinkVersion|ObjectCollection $personTeamLinkVersion  the related object to use as filter
-     * @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildPersonTeamLinkQuery The current query, for fluid interface
-     */
-    public function filterByPersonTeamLinkVersion($personTeamLinkVersion, $comparison = null)
-    {
-        if ($personTeamLinkVersion instanceof \Team\Model\PersonTeamLinkVersion) {
-            return $this
-                ->addUsingAlias(PersonTeamLinkTableMap::ID, $personTeamLinkVersion->getId(), $comparison);
-        } elseif ($personTeamLinkVersion instanceof ObjectCollection) {
-            return $this
-                ->usePersonTeamLinkVersionQuery()
-                ->filterByPrimaryKeys($personTeamLinkVersion->getPrimaryKeys())
-                ->endUse();
-        } else {
-            throw new PropelException('filterByPersonTeamLinkVersion() only accepts arguments of type \Team\Model\PersonTeamLinkVersion or Collection');
-        }
-    }
-
-    /**
-     * Adds a JOIN clause to the query using the PersonTeamLinkVersion relation
-     *
-     * @param     string $relationAlias optional alias for the relation
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return ChildPersonTeamLinkQuery The current query, for fluid interface
-     */
-    public function joinPersonTeamLinkVersion($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        $tableMap = $this->getTableMap();
-        $relationMap = $tableMap->getRelation('PersonTeamLinkVersion');
-
-        // create a ModelJoin object for this join
-        $join = new ModelJoin();
-        $join->setJoinType($joinType);
-        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
-        if ($previousJoin = $this->getPreviousJoin()) {
-            $join->setPreviousJoin($previousJoin);
-        }
-
-        // add the ModelJoin to the current object
-        if ($relationAlias) {
-            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
-            $this->addJoinObject($join, $relationAlias);
-        } else {
-            $this->addJoinObject($join, 'PersonTeamLinkVersion');
-        }
-
-        return $this;
-    }
-
-    /**
-     * Use the PersonTeamLinkVersion relation PersonTeamLinkVersion object
-     *
-     * @see useQuery()
-     *
-     * @param     string $relationAlias optional alias for the relation,
-     *                                   to be used as main alias in the secondary query
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return   \Team\Model\PersonTeamLinkVersionQuery A secondary query class using the current class as primary query
-     */
-    public function usePersonTeamLinkVersionQuery($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        return $this
-            ->joinPersonTeamLinkVersion($relationAlias, $joinType)
-            ->useQuery($relationAlias ? $relationAlias : 'PersonTeamLinkVersion', '\Team\Model\PersonTeamLinkVersionQuery');
     }
 
     /**
@@ -963,34 +754,6 @@ abstract class PersonTeamLinkQuery extends ModelCriteria
     public function firstCreatedFirst()
     {
         return $this->addAscendingOrderByColumn(PersonTeamLinkTableMap::CREATED_AT);
-    }
-
-    // versionable behavior
-
-    /**
-     * Checks whether versioning is enabled
-     *
-     * @return boolean
-     */
-    static public function isVersioningEnabled()
-    {
-        return self::$isVersioningEnabled;
-    }
-
-    /**
-     * Enables versioning
-     */
-    static public function enableVersioning()
-    {
-        self::$isVersioningEnabled = true;
-    }
-
-    /**
-     * Disables versioning
-     */
-    static public function disableVersioning()
-    {
-        self::$isVersioningEnabled = false;
     }
 
 } // PersonTeamLinkQuery

--- a/Model/Base/Team.php
+++ b/Model/Base/Team.php
@@ -19,16 +19,11 @@ use Propel\Runtime\Parser\AbstractParser;
 use Propel\Runtime\Util\PropelDateTime;
 use Team\Model\PersonTeamLink as ChildPersonTeamLink;
 use Team\Model\PersonTeamLinkQuery as ChildPersonTeamLinkQuery;
-use Team\Model\PersonTeamLinkVersionQuery as ChildPersonTeamLinkVersionQuery;
 use Team\Model\Team as ChildTeam;
 use Team\Model\TeamI18n as ChildTeamI18n;
 use Team\Model\TeamI18nQuery as ChildTeamI18nQuery;
 use Team\Model\TeamQuery as ChildTeamQuery;
-use Team\Model\TeamVersion as ChildTeamVersion;
-use Team\Model\TeamVersionQuery as ChildTeamVersionQuery;
-use Team\Model\Map\PersonTeamLinkVersionTableMap;
 use Team\Model\Map\TeamTableMap;
-use Team\Model\Map\TeamVersionTableMap;
 
 abstract class Team implements ActiveRecordInterface
 {
@@ -83,25 +78,6 @@ abstract class Team implements ActiveRecordInterface
     protected $updated_at;
 
     /**
-     * The value for the version field.
-     * Note: this column has a database default value of: 0
-     * @var        int
-     */
-    protected $version;
-
-    /**
-     * The value for the version_created_at field.
-     * @var        string
-     */
-    protected $version_created_at;
-
-    /**
-     * The value for the version_created_by field.
-     * @var        string
-     */
-    protected $version_created_by;
-
-    /**
      * @var        ObjectCollection|ChildPersonTeamLink[] Collection to store aggregation of ChildPersonTeamLink objects.
      */
     protected $collPersonTeamLinks;
@@ -112,12 +88,6 @@ abstract class Team implements ActiveRecordInterface
      */
     protected $collTeamI18ns;
     protected $collTeamI18nsPartial;
-
-    /**
-     * @var        ObjectCollection|ChildTeamVersion[] Collection to store aggregation of ChildTeamVersion objects.
-     */
-    protected $collTeamVersions;
-    protected $collTeamVersionsPartial;
 
     /**
      * Flag to prevent endless save loop, if this object is referenced
@@ -141,14 +111,6 @@ abstract class Team implements ActiveRecordInterface
      */
     protected $currentTranslations;
 
-    // versionable behavior
-
-
-    /**
-     * @var bool
-     */
-    protected $enforceVersion = false;
-
     /**
      * An array of objects scheduled for deletion.
      * @var ObjectCollection
@@ -162,29 +124,10 @@ abstract class Team implements ActiveRecordInterface
     protected $teamI18nsScheduledForDeletion = null;
 
     /**
-     * An array of objects scheduled for deletion.
-     * @var ObjectCollection
-     */
-    protected $teamVersionsScheduledForDeletion = null;
-
-    /**
-     * Applies default values to this object.
-     * This method should be called from the object's constructor (or
-     * equivalent initialization method).
-     * @see __construct()
-     */
-    public function applyDefaultValues()
-    {
-        $this->version = 0;
-    }
-
-    /**
      * Initializes internal state of Team\Model\Base\Team object.
-     * @see applyDefaults()
      */
     public function __construct()
     {
-        $this->applyDefaultValues();
     }
 
     /**
@@ -490,48 +433,6 @@ abstract class Team implements ActiveRecordInterface
     }
 
     /**
-     * Get the [version] column value.
-     *
-     * @return   int
-     */
-    public function getVersion()
-    {
-
-        return $this->version;
-    }
-
-    /**
-     * Get the [optionally formatted] temporal [version_created_at] column value.
-     *
-     *
-     * @param      string $format The date/time format string (either date()-style or strftime()-style).
-     *                            If format is NULL, then the raw \DateTime object will be returned.
-     *
-     * @return mixed Formatted date/time value as string or \DateTime object (if format is NULL), NULL if column is NULL, and 0 if column value is 0000-00-00 00:00:00
-     *
-     * @throws PropelException - if unable to parse/validate the date/time value.
-     */
-    public function getVersionCreatedAt($format = NULL)
-    {
-        if ($format === null) {
-            return $this->version_created_at;
-        } else {
-            return $this->version_created_at instanceof \DateTime ? $this->version_created_at->format($format) : null;
-        }
-    }
-
-    /**
-     * Get the [version_created_by] column value.
-     *
-     * @return   string
-     */
-    public function getVersionCreatedBy()
-    {
-
-        return $this->version_created_by;
-    }
-
-    /**
      * Set the value of [id] column.
      *
      * @param      int $v new value
@@ -595,69 +496,6 @@ abstract class Team implements ActiveRecordInterface
     } // setUpdatedAt()
 
     /**
-     * Set the value of [version] column.
-     *
-     * @param      int $v new value
-     * @return   \Team\Model\Team The current object (for fluent API support)
-     */
-    public function setVersion($v)
-    {
-        if ($v !== null) {
-            $v = (int) $v;
-        }
-
-        if ($this->version !== $v) {
-            $this->version = $v;
-            $this->modifiedColumns[TeamTableMap::VERSION] = true;
-        }
-
-
-        return $this;
-    } // setVersion()
-
-    /**
-     * Sets the value of [version_created_at] column to a normalized version of the date/time value specified.
-     *
-     * @param      mixed $v string, integer (timestamp), or \DateTime value.
-     *               Empty strings are treated as NULL.
-     * @return   \Team\Model\Team The current object (for fluent API support)
-     */
-    public function setVersionCreatedAt($v)
-    {
-        $dt = PropelDateTime::newInstance($v, null, '\DateTime');
-        if ($this->version_created_at !== null || $dt !== null) {
-            if ($dt !== $this->version_created_at) {
-                $this->version_created_at = $dt;
-                $this->modifiedColumns[TeamTableMap::VERSION_CREATED_AT] = true;
-            }
-        } // if either are not null
-
-
-        return $this;
-    } // setVersionCreatedAt()
-
-    /**
-     * Set the value of [version_created_by] column.
-     *
-     * @param      string $v new value
-     * @return   \Team\Model\Team The current object (for fluent API support)
-     */
-    public function setVersionCreatedBy($v)
-    {
-        if ($v !== null) {
-            $v = (string) $v;
-        }
-
-        if ($this->version_created_by !== $v) {
-            $this->version_created_by = $v;
-            $this->modifiedColumns[TeamTableMap::VERSION_CREATED_BY] = true;
-        }
-
-
-        return $this;
-    } // setVersionCreatedBy()
-
-    /**
      * Indicates whether the columns in this object are only set to default values.
      *
      * This method can be used in conjunction with isModified() to indicate whether an object is both
@@ -667,10 +505,6 @@ abstract class Team implements ActiveRecordInterface
      */
     public function hasOnlyDefaultValues()
     {
-            if ($this->version !== 0) {
-                return false;
-            }
-
         // otherwise, everything was equal, so return TRUE
         return true;
     } // hasOnlyDefaultValues()
@@ -712,18 +546,6 @@ abstract class Team implements ActiveRecordInterface
                 $col = null;
             }
             $this->updated_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 3 + $startcol : TeamTableMap::translateFieldName('Version', TableMap::TYPE_PHPNAME, $indexType)];
-            $this->version = (null !== $col) ? (int) $col : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 4 + $startcol : TeamTableMap::translateFieldName('VersionCreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
-            if ($col === '0000-00-00 00:00:00') {
-                $col = null;
-            }
-            $this->version_created_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
-
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : TeamTableMap::translateFieldName('VersionCreatedBy', TableMap::TYPE_PHPNAME, $indexType)];
-            $this->version_created_by = (null !== $col) ? (string) $col : null;
             $this->resetModified();
 
             $this->setNew(false);
@@ -732,7 +554,7 @@ abstract class Team implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 6; // 6 = TeamTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 3; // 3 = TeamTableMap::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception $e) {
             throw new PropelException("Error populating \Team\Model\Team object", 0, $e);
@@ -796,8 +618,6 @@ abstract class Team implements ActiveRecordInterface
             $this->collPersonTeamLinks = null;
 
             $this->collTeamI18ns = null;
-
-            $this->collTeamVersions = null;
 
         } // if (deep)
     }
@@ -867,14 +687,6 @@ abstract class Team implements ActiveRecordInterface
         $isInsert = $this->isNew();
         try {
             $ret = $this->preSave($con);
-            // versionable behavior
-            if ($this->isVersioningNecessary()) {
-                $this->setVersion($this->isNew() ? 1 : $this->getLastVersionNumber($con) + 1);
-                if (!$this->isColumnModified(TeamTableMap::VERSION_CREATED_AT)) {
-                    $this->setVersionCreatedAt(time());
-                }
-                $createVersion = true; // for postSave hook
-            }
             if ($isInsert) {
                 $ret = $ret && $this->preInsert($con);
                 // timestampable behavior
@@ -899,10 +711,6 @@ abstract class Team implements ActiveRecordInterface
                     $this->postUpdate($con);
                 }
                 $this->postSave($con);
-                // versionable behavior
-                if (isset($createVersion)) {
-                    $this->addVersion($con);
-                }
                 TeamTableMap::addInstanceToPool($this);
             } else {
                 $affectedRows = 0;
@@ -978,23 +786,6 @@ abstract class Team implements ActiveRecordInterface
                 }
             }
 
-            if ($this->teamVersionsScheduledForDeletion !== null) {
-                if (!$this->teamVersionsScheduledForDeletion->isEmpty()) {
-                    \Team\Model\TeamVersionQuery::create()
-                        ->filterByPrimaryKeys($this->teamVersionsScheduledForDeletion->getPrimaryKeys(false))
-                        ->delete($con);
-                    $this->teamVersionsScheduledForDeletion = null;
-                }
-            }
-
-                if ($this->collTeamVersions !== null) {
-            foreach ($this->collTeamVersions as $referrerFK) {
-                    if (!$referrerFK->isDeleted() && ($referrerFK->isNew() || $referrerFK->isModified())) {
-                        $affectedRows += $referrerFK->save($con);
-                    }
-                }
-            }
-
             $this->alreadyInSave = false;
 
         }
@@ -1030,15 +821,6 @@ abstract class Team implements ActiveRecordInterface
         if ($this->isColumnModified(TeamTableMap::UPDATED_AT)) {
             $modifiedColumns[':p' . $index++]  = 'UPDATED_AT';
         }
-        if ($this->isColumnModified(TeamTableMap::VERSION)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION';
-        }
-        if ($this->isColumnModified(TeamTableMap::VERSION_CREATED_AT)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION_CREATED_AT';
-        }
-        if ($this->isColumnModified(TeamTableMap::VERSION_CREATED_BY)) {
-            $modifiedColumns[':p' . $index++]  = 'VERSION_CREATED_BY';
-        }
 
         $sql = sprintf(
             'INSERT INTO team (%s) VALUES (%s)',
@@ -1058,15 +840,6 @@ abstract class Team implements ActiveRecordInterface
                         break;
                     case 'UPDATED_AT':
                         $stmt->bindValue($identifier, $this->updated_at ? $this->updated_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
-                        break;
-                    case 'VERSION':
-                        $stmt->bindValue($identifier, $this->version, PDO::PARAM_INT);
-                        break;
-                    case 'VERSION_CREATED_AT':
-                        $stmt->bindValue($identifier, $this->version_created_at ? $this->version_created_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
-                        break;
-                    case 'VERSION_CREATED_BY':
-                        $stmt->bindValue($identifier, $this->version_created_by, PDO::PARAM_STR);
                         break;
                 }
             }
@@ -1139,15 +912,6 @@ abstract class Team implements ActiveRecordInterface
             case 2:
                 return $this->getUpdatedAt();
                 break;
-            case 3:
-                return $this->getVersion();
-                break;
-            case 4:
-                return $this->getVersionCreatedAt();
-                break;
-            case 5:
-                return $this->getVersionCreatedBy();
-                break;
             default:
                 return null;
                 break;
@@ -1180,9 +944,6 @@ abstract class Team implements ActiveRecordInterface
             $keys[0] => $this->getId(),
             $keys[1] => $this->getCreatedAt(),
             $keys[2] => $this->getUpdatedAt(),
-            $keys[3] => $this->getVersion(),
-            $keys[4] => $this->getVersionCreatedAt(),
-            $keys[5] => $this->getVersionCreatedBy(),
         );
         $virtualColumns = $this->virtualColumns;
         foreach ($virtualColumns as $key => $virtualColumn) {
@@ -1195,9 +956,6 @@ abstract class Team implements ActiveRecordInterface
             }
             if (null !== $this->collTeamI18ns) {
                 $result['TeamI18ns'] = $this->collTeamI18ns->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
-            }
-            if (null !== $this->collTeamVersions) {
-                $result['TeamVersions'] = $this->collTeamVersions->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
             }
         }
 
@@ -1242,15 +1000,6 @@ abstract class Team implements ActiveRecordInterface
             case 2:
                 $this->setUpdatedAt($value);
                 break;
-            case 3:
-                $this->setVersion($value);
-                break;
-            case 4:
-                $this->setVersionCreatedAt($value);
-                break;
-            case 5:
-                $this->setVersionCreatedBy($value);
-                break;
         } // switch()
     }
 
@@ -1278,9 +1027,6 @@ abstract class Team implements ActiveRecordInterface
         if (array_key_exists($keys[0], $arr)) $this->setId($arr[$keys[0]]);
         if (array_key_exists($keys[1], $arr)) $this->setCreatedAt($arr[$keys[1]]);
         if (array_key_exists($keys[2], $arr)) $this->setUpdatedAt($arr[$keys[2]]);
-        if (array_key_exists($keys[3], $arr)) $this->setVersion($arr[$keys[3]]);
-        if (array_key_exists($keys[4], $arr)) $this->setVersionCreatedAt($arr[$keys[4]]);
-        if (array_key_exists($keys[5], $arr)) $this->setVersionCreatedBy($arr[$keys[5]]);
     }
 
     /**
@@ -1295,9 +1041,6 @@ abstract class Team implements ActiveRecordInterface
         if ($this->isColumnModified(TeamTableMap::ID)) $criteria->add(TeamTableMap::ID, $this->id);
         if ($this->isColumnModified(TeamTableMap::CREATED_AT)) $criteria->add(TeamTableMap::CREATED_AT, $this->created_at);
         if ($this->isColumnModified(TeamTableMap::UPDATED_AT)) $criteria->add(TeamTableMap::UPDATED_AT, $this->updated_at);
-        if ($this->isColumnModified(TeamTableMap::VERSION)) $criteria->add(TeamTableMap::VERSION, $this->version);
-        if ($this->isColumnModified(TeamTableMap::VERSION_CREATED_AT)) $criteria->add(TeamTableMap::VERSION_CREATED_AT, $this->version_created_at);
-        if ($this->isColumnModified(TeamTableMap::VERSION_CREATED_BY)) $criteria->add(TeamTableMap::VERSION_CREATED_BY, $this->version_created_by);
 
         return $criteria;
     }
@@ -1363,9 +1106,6 @@ abstract class Team implements ActiveRecordInterface
     {
         $copyObj->setCreatedAt($this->getCreatedAt());
         $copyObj->setUpdatedAt($this->getUpdatedAt());
-        $copyObj->setVersion($this->getVersion());
-        $copyObj->setVersionCreatedAt($this->getVersionCreatedAt());
-        $copyObj->setVersionCreatedBy($this->getVersionCreatedBy());
 
         if ($deepCopy) {
             // important: temporarily setNew(false) because this affects the behavior of
@@ -1381,12 +1121,6 @@ abstract class Team implements ActiveRecordInterface
             foreach ($this->getTeamI18ns() as $relObj) {
                 if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
                     $copyObj->addTeamI18n($relObj->copy($deepCopy));
-                }
-            }
-
-            foreach ($this->getTeamVersions() as $relObj) {
-                if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
-                    $copyObj->addTeamVersion($relObj->copy($deepCopy));
                 }
             }
 
@@ -1436,9 +1170,6 @@ abstract class Team implements ActiveRecordInterface
         }
         if ('TeamI18n' == $relationName) {
             return $this->initTeamI18ns();
-        }
-        if ('TeamVersion' == $relationName) {
-            return $this->initTeamVersions();
         }
     }
 
@@ -1911,227 +1642,6 @@ abstract class Team implements ActiveRecordInterface
     }
 
     /**
-     * Clears out the collTeamVersions collection
-     *
-     * This does not modify the database; however, it will remove any associated objects, causing
-     * them to be refetched by subsequent calls to accessor method.
-     *
-     * @return void
-     * @see        addTeamVersions()
-     */
-    public function clearTeamVersions()
-    {
-        $this->collTeamVersions = null; // important to set this to NULL since that means it is uninitialized
-    }
-
-    /**
-     * Reset is the collTeamVersions collection loaded partially.
-     */
-    public function resetPartialTeamVersions($v = true)
-    {
-        $this->collTeamVersionsPartial = $v;
-    }
-
-    /**
-     * Initializes the collTeamVersions collection.
-     *
-     * By default this just sets the collTeamVersions collection to an empty array (like clearcollTeamVersions());
-     * however, you may wish to override this method in your stub class to provide setting appropriate
-     * to your application -- for example, setting the initial array to the values stored in database.
-     *
-     * @param      boolean $overrideExisting If set to true, the method call initializes
-     *                                        the collection even if it is not empty
-     *
-     * @return void
-     */
-    public function initTeamVersions($overrideExisting = true)
-    {
-        if (null !== $this->collTeamVersions && !$overrideExisting) {
-            return;
-        }
-        $this->collTeamVersions = new ObjectCollection();
-        $this->collTeamVersions->setModel('\Team\Model\TeamVersion');
-    }
-
-    /**
-     * Gets an array of ChildTeamVersion objects which contain a foreign key that references this object.
-     *
-     * If the $criteria is not null, it is used to always fetch the results from the database.
-     * Otherwise the results are fetched from the database the first time, then cached.
-     * Next time the same method is called without $criteria, the cached collection is returned.
-     * If this ChildTeam is new, it will return
-     * an empty collection or the current collection; the criteria is ignored on a new object.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @return Collection|ChildTeamVersion[] List of ChildTeamVersion objects
-     * @throws PropelException
-     */
-    public function getTeamVersions($criteria = null, ConnectionInterface $con = null)
-    {
-        $partial = $this->collTeamVersionsPartial && !$this->isNew();
-        if (null === $this->collTeamVersions || null !== $criteria  || $partial) {
-            if ($this->isNew() && null === $this->collTeamVersions) {
-                // return empty collection
-                $this->initTeamVersions();
-            } else {
-                $collTeamVersions = ChildTeamVersionQuery::create(null, $criteria)
-                    ->filterByTeam($this)
-                    ->find($con);
-
-                if (null !== $criteria) {
-                    if (false !== $this->collTeamVersionsPartial && count($collTeamVersions)) {
-                        $this->initTeamVersions(false);
-
-                        foreach ($collTeamVersions as $obj) {
-                            if (false == $this->collTeamVersions->contains($obj)) {
-                                $this->collTeamVersions->append($obj);
-                            }
-                        }
-
-                        $this->collTeamVersionsPartial = true;
-                    }
-
-                    reset($collTeamVersions);
-
-                    return $collTeamVersions;
-                }
-
-                if ($partial && $this->collTeamVersions) {
-                    foreach ($this->collTeamVersions as $obj) {
-                        if ($obj->isNew()) {
-                            $collTeamVersions[] = $obj;
-                        }
-                    }
-                }
-
-                $this->collTeamVersions = $collTeamVersions;
-                $this->collTeamVersionsPartial = false;
-            }
-        }
-
-        return $this->collTeamVersions;
-    }
-
-    /**
-     * Sets a collection of TeamVersion objects related by a one-to-many relationship
-     * to the current object.
-     * It will also schedule objects for deletion based on a diff between old objects (aka persisted)
-     * and new objects from the given Propel collection.
-     *
-     * @param      Collection $teamVersions A Propel collection.
-     * @param      ConnectionInterface $con Optional connection object
-     * @return   ChildTeam The current object (for fluent API support)
-     */
-    public function setTeamVersions(Collection $teamVersions, ConnectionInterface $con = null)
-    {
-        $teamVersionsToDelete = $this->getTeamVersions(new Criteria(), $con)->diff($teamVersions);
-
-
-        //since at least one column in the foreign key is at the same time a PK
-        //we can not just set a PK to NULL in the lines below. We have to store
-        //a backup of all values, so we are able to manipulate these items based on the onDelete value later.
-        $this->teamVersionsScheduledForDeletion = clone $teamVersionsToDelete;
-
-        foreach ($teamVersionsToDelete as $teamVersionRemoved) {
-            $teamVersionRemoved->setTeam(null);
-        }
-
-        $this->collTeamVersions = null;
-        foreach ($teamVersions as $teamVersion) {
-            $this->addTeamVersion($teamVersion);
-        }
-
-        $this->collTeamVersions = $teamVersions;
-        $this->collTeamVersionsPartial = false;
-
-        return $this;
-    }
-
-    /**
-     * Returns the number of related TeamVersion objects.
-     *
-     * @param      Criteria $criteria
-     * @param      boolean $distinct
-     * @param      ConnectionInterface $con
-     * @return int             Count of related TeamVersion objects.
-     * @throws PropelException
-     */
-    public function countTeamVersions(Criteria $criteria = null, $distinct = false, ConnectionInterface $con = null)
-    {
-        $partial = $this->collTeamVersionsPartial && !$this->isNew();
-        if (null === $this->collTeamVersions || null !== $criteria || $partial) {
-            if ($this->isNew() && null === $this->collTeamVersions) {
-                return 0;
-            }
-
-            if ($partial && !$criteria) {
-                return count($this->getTeamVersions());
-            }
-
-            $query = ChildTeamVersionQuery::create(null, $criteria);
-            if ($distinct) {
-                $query->distinct();
-            }
-
-            return $query
-                ->filterByTeam($this)
-                ->count($con);
-        }
-
-        return count($this->collTeamVersions);
-    }
-
-    /**
-     * Method called to associate a ChildTeamVersion object to this object
-     * through the ChildTeamVersion foreign key attribute.
-     *
-     * @param    ChildTeamVersion $l ChildTeamVersion
-     * @return   \Team\Model\Team The current object (for fluent API support)
-     */
-    public function addTeamVersion(ChildTeamVersion $l)
-    {
-        if ($this->collTeamVersions === null) {
-            $this->initTeamVersions();
-            $this->collTeamVersionsPartial = true;
-        }
-
-        if (!in_array($l, $this->collTeamVersions->getArrayCopy(), true)) { // only add it if the **same** object is not already associated
-            $this->doAddTeamVersion($l);
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param TeamVersion $teamVersion The teamVersion object to add.
-     */
-    protected function doAddTeamVersion($teamVersion)
-    {
-        $this->collTeamVersions[]= $teamVersion;
-        $teamVersion->setTeam($this);
-    }
-
-    /**
-     * @param  TeamVersion $teamVersion The teamVersion object to remove.
-     * @return ChildTeam The current object (for fluent API support)
-     */
-    public function removeTeamVersion($teamVersion)
-    {
-        if ($this->getTeamVersions()->contains($teamVersion)) {
-            $this->collTeamVersions->remove($this->collTeamVersions->search($teamVersion));
-            if (null === $this->teamVersionsScheduledForDeletion) {
-                $this->teamVersionsScheduledForDeletion = clone $this->collTeamVersions;
-                $this->teamVersionsScheduledForDeletion->clear();
-            }
-            $this->teamVersionsScheduledForDeletion[]= clone $teamVersion;
-            $teamVersion->setTeam(null);
-        }
-
-        return $this;
-    }
-
-    /**
      * Clears the current object and sets all attributes to their default values
      */
     public function clear()
@@ -2139,12 +1649,8 @@ abstract class Team implements ActiveRecordInterface
         $this->id = null;
         $this->created_at = null;
         $this->updated_at = null;
-        $this->version = null;
-        $this->version_created_at = null;
-        $this->version_created_by = null;
         $this->alreadyInSave = false;
         $this->clearAllReferences();
-        $this->applyDefaultValues();
         $this->resetModified();
         $this->setNew(true);
         $this->setDeleted(false);
@@ -2172,11 +1678,6 @@ abstract class Team implements ActiveRecordInterface
                     $o->clearAllReferences($deep);
                 }
             }
-            if ($this->collTeamVersions) {
-                foreach ($this->collTeamVersions as $o) {
-                    $o->clearAllReferences($deep);
-                }
-            }
         } // if ($deep)
 
         // i18n behavior
@@ -2185,7 +1686,6 @@ abstract class Team implements ActiveRecordInterface
 
         $this->collPersonTeamLinks = null;
         $this->collTeamI18ns = null;
-        $this->collTeamVersions = null;
     }
 
     /**
@@ -2359,321 +1859,6 @@ abstract class Team implements ActiveRecordInterface
         return $this;
     }
 
-    // versionable behavior
-
-    /**
-     * Enforce a new Version of this object upon next save.
-     *
-     * @return \Team\Model\Team
-     */
-    public function enforceVersioning()
-    {
-        $this->enforceVersion = true;
-
-        return $this;
-    }
-
-    /**
-     * Checks whether the current state must be recorded as a version
-     *
-     * @return  boolean
-     */
-    public function isVersioningNecessary($con = null)
-    {
-        if ($this->alreadyInSave) {
-            return false;
-        }
-
-        if ($this->enforceVersion) {
-            return true;
-        }
-
-        if (ChildTeamQuery::isVersioningEnabled() && ($this->isNew() || $this->isModified()) || $this->isDeleted()) {
-            return true;
-        }
-        // to avoid infinite loops, emulate in save
-        $this->alreadyInSave = true;
-        foreach ($this->getPersonTeamLinks(null, $con) as $relatedObject) {
-            if ($relatedObject->isVersioningNecessary($con)) {
-                $this->alreadyInSave = false;
-
-                return true;
-            }
-        }
-        $this->alreadyInSave = false;
-
-
-        return false;
-    }
-
-    /**
-     * Creates a version of the current object and saves it.
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ChildTeamVersion A version object
-     */
-    public function addVersion($con = null)
-    {
-        $this->enforceVersion = false;
-
-        $version = new ChildTeamVersion();
-        $version->setId($this->getId());
-        $version->setCreatedAt($this->getCreatedAt());
-        $version->setUpdatedAt($this->getUpdatedAt());
-        $version->setVersion($this->getVersion());
-        $version->setVersionCreatedAt($this->getVersionCreatedAt());
-        $version->setVersionCreatedBy($this->getVersionCreatedBy());
-        $version->setTeam($this);
-        if ($relateds = $this->getPersonTeamLinks($con)->toKeyValue('Id', 'Version')) {
-            $version->setPersonTeamLinkIds(array_keys($relateds));
-            $version->setPersonTeamLinkVersions(array_values($relateds));
-        }
-        $version->save($con);
-
-        return $version;
-    }
-
-    /**
-     * Sets the properties of the current object to the value they had at a specific version
-     *
-     * @param   integer $versionNumber The version number to read
-     * @param   ConnectionInterface $con The connection to use
-     *
-     * @return  ChildTeam The current object (for fluent API support)
-     */
-    public function toVersion($versionNumber, $con = null)
-    {
-        $version = $this->getOneVersion($versionNumber, $con);
-        if (!$version) {
-            throw new PropelException(sprintf('No ChildTeam object found with version %d', $version));
-        }
-        $this->populateFromVersion($version, $con);
-
-        return $this;
-    }
-
-    /**
-     * Sets the properties of the current object to the value they had at a specific version
-     *
-     * @param ChildTeamVersion $version The version object to use
-     * @param ConnectionInterface   $con the connection to use
-     * @param array                 $loadedObjects objects that been loaded in a chain of populateFromVersion calls on referrer or fk objects.
-     *
-     * @return ChildTeam The current object (for fluent API support)
-     */
-    public function populateFromVersion($version, $con = null, &$loadedObjects = array())
-    {
-        $loadedObjects['ChildTeam'][$version->getId()][$version->getVersion()] = $this;
-        $this->setId($version->getId());
-        $this->setCreatedAt($version->getCreatedAt());
-        $this->setUpdatedAt($version->getUpdatedAt());
-        $this->setVersion($version->getVersion());
-        $this->setVersionCreatedAt($version->getVersionCreatedAt());
-        $this->setVersionCreatedBy($version->getVersionCreatedBy());
-        if ($fkValues = $version->getPersonTeamLinkIds()) {
-            $this->clearPersonTeamLinks();
-            $fkVersions = $version->getPersonTeamLinkVersions();
-            $query = ChildPersonTeamLinkVersionQuery::create();
-            foreach ($fkValues as $key => $value) {
-                $c1 = $query->getNewCriterion(PersonTeamLinkVersionTableMap::ID, $value);
-                $c2 = $query->getNewCriterion(PersonTeamLinkVersionTableMap::VERSION, $fkVersions[$key]);
-                $c1->addAnd($c2);
-                $query->addOr($c1);
-            }
-            foreach ($query->find($con) as $relatedVersion) {
-                if (isset($loadedObjects['ChildPersonTeamLink']) && isset($loadedObjects['ChildPersonTeamLink'][$relatedVersion->getId()]) && isset($loadedObjects['ChildPersonTeamLink'][$relatedVersion->getId()][$relatedVersion->getVersion()])) {
-                    $related = $loadedObjects['ChildPersonTeamLink'][$relatedVersion->getId()][$relatedVersion->getVersion()];
-                } else {
-                    $related = new ChildPersonTeamLink();
-                    $related->populateFromVersion($relatedVersion, $con, $loadedObjects);
-                    $related->setNew(false);
-                }
-                $this->addPersonTeamLink($related);
-                $this->collPersonTeamLinksPartial = false;
-            }
-        }
-
-        return $this;
-    }
-
-    /**
-     * Gets the latest persisted version number for the current object
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  integer
-     */
-    public function getLastVersionNumber($con = null)
-    {
-        $v = ChildTeamVersionQuery::create()
-            ->filterByTeam($this)
-            ->orderByVersion('desc')
-            ->findOne($con);
-        if (!$v) {
-            return 0;
-        }
-
-        return $v->getVersion();
-    }
-
-    /**
-     * Checks whether the current object is the latest one
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  Boolean
-     */
-    public function isLastVersion($con = null)
-    {
-        return $this->getLastVersionNumber($con) == $this->getVersion();
-    }
-
-    /**
-     * Retrieves a version object for this entity and a version number
-     *
-     * @param   integer $versionNumber The version number to read
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ChildTeamVersion A version object
-     */
-    public function getOneVersion($versionNumber, $con = null)
-    {
-        return ChildTeamVersionQuery::create()
-            ->filterByTeam($this)
-            ->filterByVersion($versionNumber)
-            ->findOne($con);
-    }
-
-    /**
-     * Gets all the versions of this object, in incremental order
-     *
-     * @param   ConnectionInterface $con the connection to use
-     *
-     * @return  ObjectCollection A list of ChildTeamVersion objects
-     */
-    public function getAllVersions($con = null)
-    {
-        $criteria = new Criteria();
-        $criteria->addAscendingOrderByColumn(TeamVersionTableMap::VERSION);
-
-        return $this->getTeamVersions($criteria, $con);
-    }
-
-    /**
-     * Compares the current object with another of its version.
-     * <code>
-     * print_r($book->compareVersion(1));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   integer             $versionNumber
-     * @param   string              $keys Main key used for the result diff (versions|columns)
-     * @param   ConnectionInterface $con the connection to use
-     * @param   array               $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    public function compareVersion($versionNumber, $keys = 'columns', $con = null, $ignoredColumns = array())
-    {
-        $fromVersion = $this->toArray();
-        $toVersion = $this->getOneVersion($versionNumber, $con)->toArray();
-
-        return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
-    }
-
-    /**
-     * Compares two versions of the current object.
-     * <code>
-     * print_r($book->compareVersions(1, 2));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   integer             $fromVersionNumber
-     * @param   integer             $toVersionNumber
-     * @param   string              $keys Main key used for the result diff (versions|columns)
-     * @param   ConnectionInterface $con the connection to use
-     * @param   array               $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    public function compareVersions($fromVersionNumber, $toVersionNumber, $keys = 'columns', $con = null, $ignoredColumns = array())
-    {
-        $fromVersion = $this->getOneVersion($fromVersionNumber, $con)->toArray();
-        $toVersion = $this->getOneVersion($toVersionNumber, $con)->toArray();
-
-        return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
-    }
-
-    /**
-     * Computes the diff between two versions.
-     * <code>
-     * print_r($book->computeDiff(1, 2));
-     * => array(
-     *   '1' => array('Title' => 'Book title at version 1'),
-     *   '2' => array('Title' => 'Book title at version 2')
-     * );
-     * </code>
-     *
-     * @param   array     $fromVersion     An array representing the original version.
-     * @param   array     $toVersion       An array representing the destination version.
-     * @param   string    $keys            Main key used for the result diff (versions|columns).
-     * @param   array     $ignoredColumns  The columns to exclude from the diff.
-     *
-     * @return  array A list of differences
-     */
-    protected function computeDiff($fromVersion, $toVersion, $keys = 'columns', $ignoredColumns = array())
-    {
-        $fromVersionNumber = $fromVersion['Version'];
-        $toVersionNumber = $toVersion['Version'];
-        $ignoredColumns = array_merge(array(
-            'Version',
-            'VersionCreatedAt',
-            'VersionCreatedBy',
-        ), $ignoredColumns);
-        $diff = array();
-        foreach ($fromVersion as $key => $value) {
-            if (in_array($key, $ignoredColumns)) {
-                continue;
-            }
-            if ($toVersion[$key] != $value) {
-                switch ($keys) {
-                    case 'versions':
-                        $diff[$fromVersionNumber][$key] = $value;
-                        $diff[$toVersionNumber][$key] = $toVersion[$key];
-                        break;
-                    default:
-                        $diff[$key] = array(
-                            $fromVersionNumber => $value,
-                            $toVersionNumber => $toVersion[$key],
-                        );
-                        break;
-                }
-            }
-        }
-
-        return $diff;
-    }
-    /**
-     * retrieve the last $number versions.
-     *
-     * @param Integer $number the number of record to return.
-     * @return PropelCollection|array \Team\Model\TeamVersion[] List of \Team\Model\TeamVersion objects
-     */
-    public function getLastVersions($number = 10, $criteria = null, $con = null)
-    {
-        $criteria = ChildTeamVersionQuery::create(null, $criteria);
-        $criteria->addDescendingOrderByColumn(TeamVersionTableMap::VERSION);
-        $criteria->limit($number);
-
-        return $this->getTeamVersions($criteria, $con);
-    }
     /**
      * Code to be run before persisting the object
      * @param  ConnectionInterface $con

--- a/Model/Base/TeamQuery.php
+++ b/Model/Base/TeamQuery.php
@@ -25,16 +25,10 @@ use Team\Model\Map\TeamTableMap;
  * @method     ChildTeamQuery orderById($order = Criteria::ASC) Order by the id column
  * @method     ChildTeamQuery orderByCreatedAt($order = Criteria::ASC) Order by the created_at column
  * @method     ChildTeamQuery orderByUpdatedAt($order = Criteria::ASC) Order by the updated_at column
- * @method     ChildTeamQuery orderByVersion($order = Criteria::ASC) Order by the version column
- * @method     ChildTeamQuery orderByVersionCreatedAt($order = Criteria::ASC) Order by the version_created_at column
- * @method     ChildTeamQuery orderByVersionCreatedBy($order = Criteria::ASC) Order by the version_created_by column
  *
  * @method     ChildTeamQuery groupById() Group by the id column
  * @method     ChildTeamQuery groupByCreatedAt() Group by the created_at column
  * @method     ChildTeamQuery groupByUpdatedAt() Group by the updated_at column
- * @method     ChildTeamQuery groupByVersion() Group by the version column
- * @method     ChildTeamQuery groupByVersionCreatedAt() Group by the version_created_at column
- * @method     ChildTeamQuery groupByVersionCreatedBy() Group by the version_created_by column
  *
  * @method     ChildTeamQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
  * @method     ChildTeamQuery rightJoin($relation) Adds a RIGHT JOIN clause to the query
@@ -48,37 +42,20 @@ use Team\Model\Map\TeamTableMap;
  * @method     ChildTeamQuery rightJoinTeamI18n($relationAlias = null) Adds a RIGHT JOIN clause to the query using the TeamI18n relation
  * @method     ChildTeamQuery innerJoinTeamI18n($relationAlias = null) Adds a INNER JOIN clause to the query using the TeamI18n relation
  *
- * @method     ChildTeamQuery leftJoinTeamVersion($relationAlias = null) Adds a LEFT JOIN clause to the query using the TeamVersion relation
- * @method     ChildTeamQuery rightJoinTeamVersion($relationAlias = null) Adds a RIGHT JOIN clause to the query using the TeamVersion relation
- * @method     ChildTeamQuery innerJoinTeamVersion($relationAlias = null) Adds a INNER JOIN clause to the query using the TeamVersion relation
- *
  * @method     ChildTeam findOne(ConnectionInterface $con = null) Return the first ChildTeam matching the query
  * @method     ChildTeam findOneOrCreate(ConnectionInterface $con = null) Return the first ChildTeam matching the query, or a new ChildTeam object populated from the query conditions when no match is found
  *
  * @method     ChildTeam findOneById(int $id) Return the first ChildTeam filtered by the id column
  * @method     ChildTeam findOneByCreatedAt(string $created_at) Return the first ChildTeam filtered by the created_at column
  * @method     ChildTeam findOneByUpdatedAt(string $updated_at) Return the first ChildTeam filtered by the updated_at column
- * @method     ChildTeam findOneByVersion(int $version) Return the first ChildTeam filtered by the version column
- * @method     ChildTeam findOneByVersionCreatedAt(string $version_created_at) Return the first ChildTeam filtered by the version_created_at column
- * @method     ChildTeam findOneByVersionCreatedBy(string $version_created_by) Return the first ChildTeam filtered by the version_created_by column
  *
  * @method     array findById(int $id) Return ChildTeam objects filtered by the id column
  * @method     array findByCreatedAt(string $created_at) Return ChildTeam objects filtered by the created_at column
  * @method     array findByUpdatedAt(string $updated_at) Return ChildTeam objects filtered by the updated_at column
- * @method     array findByVersion(int $version) Return ChildTeam objects filtered by the version column
- * @method     array findByVersionCreatedAt(string $version_created_at) Return ChildTeam objects filtered by the version_created_at column
- * @method     array findByVersionCreatedBy(string $version_created_by) Return ChildTeam objects filtered by the version_created_by column
  *
  */
 abstract class TeamQuery extends ModelCriteria
 {
-
-    // versionable behavior
-
-    /**
-     * Whether the versioning is enabled
-     */
-    static $isVersioningEnabled = true;
 
     /**
      * Initializes internal state of \Team\Model\Base\TeamQuery object.
@@ -163,7 +140,7 @@ abstract class TeamQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT ID, CREATED_AT, UPDATED_AT, VERSION, VERSION_CREATED_AT, VERSION_CREATED_BY FROM team WHERE ID = :p0';
+        $sql = 'SELECT ID, CREATED_AT, UPDATED_AT FROM team WHERE ID = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -380,119 +357,6 @@ abstract class TeamQuery extends ModelCriteria
     }
 
     /**
-     * Filter the query on the version column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersion(1234); // WHERE version = 1234
-     * $query->filterByVersion(array(12, 34)); // WHERE version IN (12, 34)
-     * $query->filterByVersion(array('min' => 12)); // WHERE version > 12
-     * </code>
-     *
-     * @param     mixed $version The value to use as filter.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildTeamQuery The current query, for fluid interface
-     */
-    public function filterByVersion($version = null, $comparison = null)
-    {
-        if (is_array($version)) {
-            $useMinMax = false;
-            if (isset($version['min'])) {
-                $this->addUsingAlias(TeamTableMap::VERSION, $version['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($version['max'])) {
-                $this->addUsingAlias(TeamTableMap::VERSION, $version['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(TeamTableMap::VERSION, $version, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_at column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedAt('2011-03-14'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt('now'); // WHERE version_created_at = '2011-03-14'
-     * $query->filterByVersionCreatedAt(array('max' => 'yesterday')); // WHERE version_created_at > '2011-03-13'
-     * </code>
-     *
-     * @param     mixed $versionCreatedAt The value to use as filter.
-     *              Values can be integers (unix timestamps), DateTime objects, or strings.
-     *              Empty strings are treated as NULL.
-     *              Use scalar values for equality.
-     *              Use array values for in_array() equivalent.
-     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildTeamQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedAt($versionCreatedAt = null, $comparison = null)
-    {
-        if (is_array($versionCreatedAt)) {
-            $useMinMax = false;
-            if (isset($versionCreatedAt['min'])) {
-                $this->addUsingAlias(TeamTableMap::VERSION_CREATED_AT, $versionCreatedAt['min'], Criteria::GREATER_EQUAL);
-                $useMinMax = true;
-            }
-            if (isset($versionCreatedAt['max'])) {
-                $this->addUsingAlias(TeamTableMap::VERSION_CREATED_AT, $versionCreatedAt['max'], Criteria::LESS_EQUAL);
-                $useMinMax = true;
-            }
-            if ($useMinMax) {
-                return $this;
-            }
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-        }
-
-        return $this->addUsingAlias(TeamTableMap::VERSION_CREATED_AT, $versionCreatedAt, $comparison);
-    }
-
-    /**
-     * Filter the query on the version_created_by column
-     *
-     * Example usage:
-     * <code>
-     * $query->filterByVersionCreatedBy('fooValue');   // WHERE version_created_by = 'fooValue'
-     * $query->filterByVersionCreatedBy('%fooValue%'); // WHERE version_created_by LIKE '%fooValue%'
-     * </code>
-     *
-     * @param     string $versionCreatedBy The value to use as filter.
-     *              Accepts wildcards (* and % trigger a LIKE)
-     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildTeamQuery The current query, for fluid interface
-     */
-    public function filterByVersionCreatedBy($versionCreatedBy = null, $comparison = null)
-    {
-        if (null === $comparison) {
-            if (is_array($versionCreatedBy)) {
-                $comparison = Criteria::IN;
-            } elseif (preg_match('/[\%\*]/', $versionCreatedBy)) {
-                $versionCreatedBy = str_replace('*', '%', $versionCreatedBy);
-                $comparison = Criteria::LIKE;
-            }
-        }
-
-        return $this->addUsingAlias(TeamTableMap::VERSION_CREATED_BY, $versionCreatedBy, $comparison);
-    }
-
-    /**
      * Filter the query by a related \Team\Model\PersonTeamLink object
      *
      * @param \Team\Model\PersonTeamLink|ObjectCollection $personTeamLink  the related object to use as filter
@@ -636,79 +500,6 @@ abstract class TeamQuery extends ModelCriteria
         return $this
             ->joinTeamI18n($relationAlias, $joinType)
             ->useQuery($relationAlias ? $relationAlias : 'TeamI18n', '\Team\Model\TeamI18nQuery');
-    }
-
-    /**
-     * Filter the query by a related \Team\Model\TeamVersion object
-     *
-     * @param \Team\Model\TeamVersion|ObjectCollection $teamVersion  the related object to use as filter
-     * @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildTeamQuery The current query, for fluid interface
-     */
-    public function filterByTeamVersion($teamVersion, $comparison = null)
-    {
-        if ($teamVersion instanceof \Team\Model\TeamVersion) {
-            return $this
-                ->addUsingAlias(TeamTableMap::ID, $teamVersion->getId(), $comparison);
-        } elseif ($teamVersion instanceof ObjectCollection) {
-            return $this
-                ->useTeamVersionQuery()
-                ->filterByPrimaryKeys($teamVersion->getPrimaryKeys())
-                ->endUse();
-        } else {
-            throw new PropelException('filterByTeamVersion() only accepts arguments of type \Team\Model\TeamVersion or Collection');
-        }
-    }
-
-    /**
-     * Adds a JOIN clause to the query using the TeamVersion relation
-     *
-     * @param     string $relationAlias optional alias for the relation
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return ChildTeamQuery The current query, for fluid interface
-     */
-    public function joinTeamVersion($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        $tableMap = $this->getTableMap();
-        $relationMap = $tableMap->getRelation('TeamVersion');
-
-        // create a ModelJoin object for this join
-        $join = new ModelJoin();
-        $join->setJoinType($joinType);
-        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
-        if ($previousJoin = $this->getPreviousJoin()) {
-            $join->setPreviousJoin($previousJoin);
-        }
-
-        // add the ModelJoin to the current object
-        if ($relationAlias) {
-            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
-            $this->addJoinObject($join, $relationAlias);
-        } else {
-            $this->addJoinObject($join, 'TeamVersion');
-        }
-
-        return $this;
-    }
-
-    /**
-     * Use the TeamVersion relation TeamVersion object
-     *
-     * @see useQuery()
-     *
-     * @param     string $relationAlias optional alias for the relation,
-     *                                   to be used as main alias in the secondary query
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return   \Team\Model\TeamVersionQuery A secondary query class using the current class as primary query
-     */
-    public function useTeamVersionQuery($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        return $this
-            ->joinTeamVersion($relationAlias, $joinType)
-            ->useQuery($relationAlias ? $relationAlias : 'TeamVersion', '\Team\Model\TeamVersionQuery');
     }
 
     /**
@@ -923,34 +714,6 @@ abstract class TeamQuery extends ModelCriteria
         return $this
             ->joinI18n($locale, $relationAlias, $joinType)
             ->useQuery($relationAlias ? $relationAlias : 'TeamI18n', '\Team\Model\TeamI18nQuery');
-    }
-
-    // versionable behavior
-
-    /**
-     * Checks whether versioning is enabled
-     *
-     * @return boolean
-     */
-    static public function isVersioningEnabled()
-    {
-        return self::$isVersioningEnabled;
-    }
-
-    /**
-     * Enables versioning
-     */
-    static public function enableVersioning()
-    {
-        self::$isVersioningEnabled = true;
-    }
-
-    /**
-     * Disables versioning
-     */
-    static public function disableVersioning()
-    {
-        self::$isVersioningEnabled = false;
     }
 
 } // TeamQuery

--- a/Model/Map/PersonFunctionLinkTableMap.php
+++ b/Model/Map/PersonFunctionLinkTableMap.php
@@ -58,7 +58,7 @@ class PersonFunctionLinkTableMap extends TableMap
     /**
      * The total number of columns
      */
-    const NUM_COLUMNS = 8;
+    const NUM_COLUMNS = 5;
 
     /**
      * The number of lazy-loaded columns
@@ -68,7 +68,7 @@ class PersonFunctionLinkTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    const NUM_HYDRATE_COLUMNS = 8;
+    const NUM_HYDRATE_COLUMNS = 5;
 
     /**
      * the column name for the ID field
@@ -96,21 +96,6 @@ class PersonFunctionLinkTableMap extends TableMap
     const UPDATED_AT = 'person_function_link.UPDATED_AT';
 
     /**
-     * the column name for the VERSION field
-     */
-    const VERSION = 'person_function_link.VERSION';
-
-    /**
-     * the column name for the VERSION_CREATED_AT field
-     */
-    const VERSION_CREATED_AT = 'person_function_link.VERSION_CREATED_AT';
-
-    /**
-     * the column name for the VERSION_CREATED_BY field
-     */
-    const VERSION_CREATED_BY = 'person_function_link.VERSION_CREATED_BY';
-
-    /**
      * The default string format for model objects of the related table
      */
     const DEFAULT_STRING_FORMAT = 'YAML';
@@ -122,12 +107,12 @@ class PersonFunctionLinkTableMap extends TableMap
      * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
      */
     protected static $fieldNames = array (
-        self::TYPE_PHPNAME       => array('Id', 'PersonId', 'FunctionId', 'CreatedAt', 'UpdatedAt', 'Version', 'VersionCreatedAt', 'VersionCreatedBy', ),
-        self::TYPE_STUDLYPHPNAME => array('id', 'personId', 'functionId', 'createdAt', 'updatedAt', 'version', 'versionCreatedAt', 'versionCreatedBy', ),
-        self::TYPE_COLNAME       => array(PersonFunctionLinkTableMap::ID, PersonFunctionLinkTableMap::PERSON_ID, PersonFunctionLinkTableMap::FUNCTION_ID, PersonFunctionLinkTableMap::CREATED_AT, PersonFunctionLinkTableMap::UPDATED_AT, PersonFunctionLinkTableMap::VERSION, PersonFunctionLinkTableMap::VERSION_CREATED_AT, PersonFunctionLinkTableMap::VERSION_CREATED_BY, ),
-        self::TYPE_RAW_COLNAME   => array('ID', 'PERSON_ID', 'FUNCTION_ID', 'CREATED_AT', 'UPDATED_AT', 'VERSION', 'VERSION_CREATED_AT', 'VERSION_CREATED_BY', ),
-        self::TYPE_FIELDNAME     => array('id', 'person_id', 'function_id', 'created_at', 'updated_at', 'version', 'version_created_at', 'version_created_by', ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, )
+        self::TYPE_PHPNAME       => array('Id', 'PersonId', 'FunctionId', 'CreatedAt', 'UpdatedAt', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'personId', 'functionId', 'createdAt', 'updatedAt', ),
+        self::TYPE_COLNAME       => array(PersonFunctionLinkTableMap::ID, PersonFunctionLinkTableMap::PERSON_ID, PersonFunctionLinkTableMap::FUNCTION_ID, PersonFunctionLinkTableMap::CREATED_AT, PersonFunctionLinkTableMap::UPDATED_AT, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'PERSON_ID', 'FUNCTION_ID', 'CREATED_AT', 'UPDATED_AT', ),
+        self::TYPE_FIELDNAME     => array('id', 'person_id', 'function_id', 'created_at', 'updated_at', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, )
     );
 
     /**
@@ -137,12 +122,12 @@ class PersonFunctionLinkTableMap extends TableMap
      * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
      */
     protected static $fieldKeys = array (
-        self::TYPE_PHPNAME       => array('Id' => 0, 'PersonId' => 1, 'FunctionId' => 2, 'CreatedAt' => 3, 'UpdatedAt' => 4, 'Version' => 5, 'VersionCreatedAt' => 6, 'VersionCreatedBy' => 7, ),
-        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'personId' => 1, 'functionId' => 2, 'createdAt' => 3, 'updatedAt' => 4, 'version' => 5, 'versionCreatedAt' => 6, 'versionCreatedBy' => 7, ),
-        self::TYPE_COLNAME       => array(PersonFunctionLinkTableMap::ID => 0, PersonFunctionLinkTableMap::PERSON_ID => 1, PersonFunctionLinkTableMap::FUNCTION_ID => 2, PersonFunctionLinkTableMap::CREATED_AT => 3, PersonFunctionLinkTableMap::UPDATED_AT => 4, PersonFunctionLinkTableMap::VERSION => 5, PersonFunctionLinkTableMap::VERSION_CREATED_AT => 6, PersonFunctionLinkTableMap::VERSION_CREATED_BY => 7, ),
-        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'PERSON_ID' => 1, 'FUNCTION_ID' => 2, 'CREATED_AT' => 3, 'UPDATED_AT' => 4, 'VERSION' => 5, 'VERSION_CREATED_AT' => 6, 'VERSION_CREATED_BY' => 7, ),
-        self::TYPE_FIELDNAME     => array('id' => 0, 'person_id' => 1, 'function_id' => 2, 'created_at' => 3, 'updated_at' => 4, 'version' => 5, 'version_created_at' => 6, 'version_created_by' => 7, ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, )
+        self::TYPE_PHPNAME       => array('Id' => 0, 'PersonId' => 1, 'FunctionId' => 2, 'CreatedAt' => 3, 'UpdatedAt' => 4, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'personId' => 1, 'functionId' => 2, 'createdAt' => 3, 'updatedAt' => 4, ),
+        self::TYPE_COLNAME       => array(PersonFunctionLinkTableMap::ID => 0, PersonFunctionLinkTableMap::PERSON_ID => 1, PersonFunctionLinkTableMap::FUNCTION_ID => 2, PersonFunctionLinkTableMap::CREATED_AT => 3, PersonFunctionLinkTableMap::UPDATED_AT => 4, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'PERSON_ID' => 1, 'FUNCTION_ID' => 2, 'CREATED_AT' => 3, 'UPDATED_AT' => 4, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'person_id' => 1, 'function_id' => 2, 'created_at' => 3, 'updated_at' => 4, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, )
     );
 
     /**
@@ -166,9 +151,6 @@ class PersonFunctionLinkTableMap extends TableMap
         $this->addForeignKey('FUNCTION_ID', 'FunctionId', 'INTEGER', 'person_function', 'ID', true, null, null);
         $this->addColumn('CREATED_AT', 'CreatedAt', 'TIMESTAMP', false, null, null);
         $this->addColumn('UPDATED_AT', 'UpdatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION', 'Version', 'INTEGER', false, null, 0);
-        $this->addColumn('VERSION_CREATED_AT', 'VersionCreatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION_CREATED_BY', 'VersionCreatedBy', 'VARCHAR', false, 100, null);
     } // initialize()
 
     /**
@@ -178,7 +160,6 @@ class PersonFunctionLinkTableMap extends TableMap
     {
         $this->addRelation('Person', '\\Team\\Model\\Person', RelationMap::MANY_TO_ONE, array('person_id' => 'id', ), 'CASCADE', null);
         $this->addRelation('PersonFunction', '\\Team\\Model\\PersonFunction', RelationMap::MANY_TO_ONE, array('function_id' => 'id', ), 'CASCADE', null);
-        $this->addRelation('PersonFunctionLinkVersion', '\\Team\\Model\\PersonFunctionLinkVersion', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'PersonFunctionLinkVersions');
     } // buildRelations()
 
     /**
@@ -191,18 +172,8 @@ class PersonFunctionLinkTableMap extends TableMap
     {
         return array(
             'timestampable' => array('create_column' => 'created_at', 'update_column' => 'updated_at', ),
-            'versionable' => array('version_column' => 'version', 'version_table' => '', 'log_created_at' => 'true', 'log_created_by' => 'true', 'log_comment' => 'false', 'version_created_at_column' => 'version_created_at', 'version_created_by_column' => 'version_created_by', 'version_comment_column' => 'version_comment', ),
         );
     } // getBehaviors()
-    /**
-     * Method to invalidate the instance pool of all tables related to person_function_link     * by a foreign key with ON DELETE CASCADE
-     */
-    public static function clearRelatedInstancePool()
-    {
-        // Invalidate objects in ".$this->getClassNameFromBuilder($joinedTableTableMapBuilder)." instance pool,
-        // since one or more of them may be deleted by ON DELETE CASCADE/SETNULL rule.
-                PersonFunctionLinkVersionTableMap::clearInstancePool();
-            }
 
     /**
      * Retrieves a string version of the primary key from the DB resultset row that can be used to uniquely identify a row in this table.
@@ -347,18 +318,12 @@ class PersonFunctionLinkTableMap extends TableMap
             $criteria->addSelectColumn(PersonFunctionLinkTableMap::FUNCTION_ID);
             $criteria->addSelectColumn(PersonFunctionLinkTableMap::CREATED_AT);
             $criteria->addSelectColumn(PersonFunctionLinkTableMap::UPDATED_AT);
-            $criteria->addSelectColumn(PersonFunctionLinkTableMap::VERSION);
-            $criteria->addSelectColumn(PersonFunctionLinkTableMap::VERSION_CREATED_AT);
-            $criteria->addSelectColumn(PersonFunctionLinkTableMap::VERSION_CREATED_BY);
         } else {
             $criteria->addSelectColumn($alias . '.ID');
             $criteria->addSelectColumn($alias . '.PERSON_ID');
             $criteria->addSelectColumn($alias . '.FUNCTION_ID');
             $criteria->addSelectColumn($alias . '.CREATED_AT');
             $criteria->addSelectColumn($alias . '.UPDATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_BY');
         }
     }
 

--- a/Model/Map/PersonFunctionTableMap.php
+++ b/Model/Map/PersonFunctionTableMap.php
@@ -58,7 +58,7 @@ class PersonFunctionTableMap extends TableMap
     /**
      * The total number of columns
      */
-    const NUM_COLUMNS = 7;
+    const NUM_COLUMNS = 4;
 
     /**
      * The number of lazy-loaded columns
@@ -68,7 +68,7 @@ class PersonFunctionTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    const NUM_HYDRATE_COLUMNS = 7;
+    const NUM_HYDRATE_COLUMNS = 4;
 
     /**
      * the column name for the ID field
@@ -91,21 +91,6 @@ class PersonFunctionTableMap extends TableMap
     const UPDATED_AT = 'person_function.UPDATED_AT';
 
     /**
-     * the column name for the VERSION field
-     */
-    const VERSION = 'person_function.VERSION';
-
-    /**
-     * the column name for the VERSION_CREATED_AT field
-     */
-    const VERSION_CREATED_AT = 'person_function.VERSION_CREATED_AT';
-
-    /**
-     * the column name for the VERSION_CREATED_BY field
-     */
-    const VERSION_CREATED_BY = 'person_function.VERSION_CREATED_BY';
-
-    /**
      * The default string format for model objects of the related table
      */
     const DEFAULT_STRING_FORMAT = 'YAML';
@@ -126,12 +111,12 @@ class PersonFunctionTableMap extends TableMap
      * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
      */
     protected static $fieldNames = array (
-        self::TYPE_PHPNAME       => array('Id', 'Code', 'CreatedAt', 'UpdatedAt', 'Version', 'VersionCreatedAt', 'VersionCreatedBy', ),
-        self::TYPE_STUDLYPHPNAME => array('id', 'code', 'createdAt', 'updatedAt', 'version', 'versionCreatedAt', 'versionCreatedBy', ),
-        self::TYPE_COLNAME       => array(PersonFunctionTableMap::ID, PersonFunctionTableMap::CODE, PersonFunctionTableMap::CREATED_AT, PersonFunctionTableMap::UPDATED_AT, PersonFunctionTableMap::VERSION, PersonFunctionTableMap::VERSION_CREATED_AT, PersonFunctionTableMap::VERSION_CREATED_BY, ),
-        self::TYPE_RAW_COLNAME   => array('ID', 'CODE', 'CREATED_AT', 'UPDATED_AT', 'VERSION', 'VERSION_CREATED_AT', 'VERSION_CREATED_BY', ),
-        self::TYPE_FIELDNAME     => array('id', 'code', 'created_at', 'updated_at', 'version', 'version_created_at', 'version_created_by', ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, )
+        self::TYPE_PHPNAME       => array('Id', 'Code', 'CreatedAt', 'UpdatedAt', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'code', 'createdAt', 'updatedAt', ),
+        self::TYPE_COLNAME       => array(PersonFunctionTableMap::ID, PersonFunctionTableMap::CODE, PersonFunctionTableMap::CREATED_AT, PersonFunctionTableMap::UPDATED_AT, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'CODE', 'CREATED_AT', 'UPDATED_AT', ),
+        self::TYPE_FIELDNAME     => array('id', 'code', 'created_at', 'updated_at', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, )
     );
 
     /**
@@ -141,12 +126,12 @@ class PersonFunctionTableMap extends TableMap
      * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
      */
     protected static $fieldKeys = array (
-        self::TYPE_PHPNAME       => array('Id' => 0, 'Code' => 1, 'CreatedAt' => 2, 'UpdatedAt' => 3, 'Version' => 4, 'VersionCreatedAt' => 5, 'VersionCreatedBy' => 6, ),
-        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'code' => 1, 'createdAt' => 2, 'updatedAt' => 3, 'version' => 4, 'versionCreatedAt' => 5, 'versionCreatedBy' => 6, ),
-        self::TYPE_COLNAME       => array(PersonFunctionTableMap::ID => 0, PersonFunctionTableMap::CODE => 1, PersonFunctionTableMap::CREATED_AT => 2, PersonFunctionTableMap::UPDATED_AT => 3, PersonFunctionTableMap::VERSION => 4, PersonFunctionTableMap::VERSION_CREATED_AT => 5, PersonFunctionTableMap::VERSION_CREATED_BY => 6, ),
-        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'CODE' => 1, 'CREATED_AT' => 2, 'UPDATED_AT' => 3, 'VERSION' => 4, 'VERSION_CREATED_AT' => 5, 'VERSION_CREATED_BY' => 6, ),
-        self::TYPE_FIELDNAME     => array('id' => 0, 'code' => 1, 'created_at' => 2, 'updated_at' => 3, 'version' => 4, 'version_created_at' => 5, 'version_created_by' => 6, ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, )
+        self::TYPE_PHPNAME       => array('Id' => 0, 'Code' => 1, 'CreatedAt' => 2, 'UpdatedAt' => 3, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'code' => 1, 'createdAt' => 2, 'updatedAt' => 3, ),
+        self::TYPE_COLNAME       => array(PersonFunctionTableMap::ID => 0, PersonFunctionTableMap::CODE => 1, PersonFunctionTableMap::CREATED_AT => 2, PersonFunctionTableMap::UPDATED_AT => 3, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'CODE' => 1, 'CREATED_AT' => 2, 'UPDATED_AT' => 3, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'code' => 1, 'created_at' => 2, 'updated_at' => 3, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, )
     );
 
     /**
@@ -169,9 +154,6 @@ class PersonFunctionTableMap extends TableMap
         $this->addColumn('CODE', 'Code', 'VARCHAR', false, 255, null);
         $this->addColumn('CREATED_AT', 'CreatedAt', 'TIMESTAMP', false, null, null);
         $this->addColumn('UPDATED_AT', 'UpdatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION', 'Version', 'INTEGER', false, null, 0);
-        $this->addColumn('VERSION_CREATED_AT', 'VersionCreatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION_CREATED_BY', 'VersionCreatedBy', 'VARCHAR', false, 100, null);
     } // initialize()
 
     /**
@@ -181,7 +163,6 @@ class PersonFunctionTableMap extends TableMap
     {
         $this->addRelation('PersonFunctionLink', '\\Team\\Model\\PersonFunctionLink', RelationMap::ONE_TO_MANY, array('id' => 'function_id', ), 'CASCADE', null, 'PersonFunctionLinks');
         $this->addRelation('PersonFunctionI18n', '\\Team\\Model\\PersonFunctionI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'PersonFunctionI18ns');
-        $this->addRelation('PersonFunctionVersion', '\\Team\\Model\\PersonFunctionVersion', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'PersonFunctionVersions');
     } // buildRelations()
 
     /**
@@ -195,7 +176,6 @@ class PersonFunctionTableMap extends TableMap
         return array(
             'timestampable' => array('create_column' => 'created_at', 'update_column' => 'updated_at', ),
             'i18n' => array('i18n_table' => '%TABLE%_i18n', 'i18n_phpname' => '%PHPNAME%I18n', 'i18n_columns' => 'label', 'locale_column' => 'locale', 'locale_length' => '5', 'default_locale' => '', 'locale_alias' => '', ),
-            'versionable' => array('version_column' => 'version', 'version_table' => '', 'log_created_at' => 'true', 'log_created_by' => 'true', 'log_comment' => 'false', 'version_created_at_column' => 'version_created_at', 'version_created_by_column' => 'version_created_by', 'version_comment_column' => 'version_comment', ),
         );
     } // getBehaviors()
     /**
@@ -207,7 +187,6 @@ class PersonFunctionTableMap extends TableMap
         // since one or more of them may be deleted by ON DELETE CASCADE/SETNULL rule.
                 PersonFunctionLinkTableMap::clearInstancePool();
                 PersonFunctionI18nTableMap::clearInstancePool();
-                PersonFunctionVersionTableMap::clearInstancePool();
             }
 
     /**
@@ -352,17 +331,11 @@ class PersonFunctionTableMap extends TableMap
             $criteria->addSelectColumn(PersonFunctionTableMap::CODE);
             $criteria->addSelectColumn(PersonFunctionTableMap::CREATED_AT);
             $criteria->addSelectColumn(PersonFunctionTableMap::UPDATED_AT);
-            $criteria->addSelectColumn(PersonFunctionTableMap::VERSION);
-            $criteria->addSelectColumn(PersonFunctionTableMap::VERSION_CREATED_AT);
-            $criteria->addSelectColumn(PersonFunctionTableMap::VERSION_CREATED_BY);
         } else {
             $criteria->addSelectColumn($alias . '.ID');
             $criteria->addSelectColumn($alias . '.CODE');
             $criteria->addSelectColumn($alias . '.CREATED_AT');
             $criteria->addSelectColumn($alias . '.UPDATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_BY');
         }
     }
 

--- a/Model/Map/PersonImageTableMap.php
+++ b/Model/Map/PersonImageTableMap.php
@@ -58,7 +58,7 @@ class PersonImageTableMap extends TableMap
     /**
      * The total number of columns
      */
-    const NUM_COLUMNS = 10;
+    const NUM_COLUMNS = 7;
 
     /**
      * The number of lazy-loaded columns
@@ -68,7 +68,7 @@ class PersonImageTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    const NUM_HYDRATE_COLUMNS = 10;
+    const NUM_HYDRATE_COLUMNS = 7;
 
     /**
      * the column name for the ID field
@@ -106,21 +106,6 @@ class PersonImageTableMap extends TableMap
     const UPDATED_AT = 'person_image.UPDATED_AT';
 
     /**
-     * the column name for the VERSION field
-     */
-    const VERSION = 'person_image.VERSION';
-
-    /**
-     * the column name for the VERSION_CREATED_AT field
-     */
-    const VERSION_CREATED_AT = 'person_image.VERSION_CREATED_AT';
-
-    /**
-     * the column name for the VERSION_CREATED_BY field
-     */
-    const VERSION_CREATED_BY = 'person_image.VERSION_CREATED_BY';
-
-    /**
      * The default string format for model objects of the related table
      */
     const DEFAULT_STRING_FORMAT = 'YAML';
@@ -141,12 +126,12 @@ class PersonImageTableMap extends TableMap
      * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
      */
     protected static $fieldNames = array (
-        self::TYPE_PHPNAME       => array('Id', 'File', 'PersonId', 'Visible', 'Position', 'CreatedAt', 'UpdatedAt', 'Version', 'VersionCreatedAt', 'VersionCreatedBy', ),
-        self::TYPE_STUDLYPHPNAME => array('id', 'file', 'personId', 'visible', 'position', 'createdAt', 'updatedAt', 'version', 'versionCreatedAt', 'versionCreatedBy', ),
-        self::TYPE_COLNAME       => array(PersonImageTableMap::ID, PersonImageTableMap::FILE, PersonImageTableMap::PERSON_ID, PersonImageTableMap::VISIBLE, PersonImageTableMap::POSITION, PersonImageTableMap::CREATED_AT, PersonImageTableMap::UPDATED_AT, PersonImageTableMap::VERSION, PersonImageTableMap::VERSION_CREATED_AT, PersonImageTableMap::VERSION_CREATED_BY, ),
-        self::TYPE_RAW_COLNAME   => array('ID', 'FILE', 'PERSON_ID', 'VISIBLE', 'POSITION', 'CREATED_AT', 'UPDATED_AT', 'VERSION', 'VERSION_CREATED_AT', 'VERSION_CREATED_BY', ),
-        self::TYPE_FIELDNAME     => array('id', 'file', 'person_id', 'visible', 'position', 'created_at', 'updated_at', 'version', 'version_created_at', 'version_created_by', ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, )
+        self::TYPE_PHPNAME       => array('Id', 'File', 'PersonId', 'Visible', 'Position', 'CreatedAt', 'UpdatedAt', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'file', 'personId', 'visible', 'position', 'createdAt', 'updatedAt', ),
+        self::TYPE_COLNAME       => array(PersonImageTableMap::ID, PersonImageTableMap::FILE, PersonImageTableMap::PERSON_ID, PersonImageTableMap::VISIBLE, PersonImageTableMap::POSITION, PersonImageTableMap::CREATED_AT, PersonImageTableMap::UPDATED_AT, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'FILE', 'PERSON_ID', 'VISIBLE', 'POSITION', 'CREATED_AT', 'UPDATED_AT', ),
+        self::TYPE_FIELDNAME     => array('id', 'file', 'person_id', 'visible', 'position', 'created_at', 'updated_at', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, )
     );
 
     /**
@@ -156,12 +141,12 @@ class PersonImageTableMap extends TableMap
      * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
      */
     protected static $fieldKeys = array (
-        self::TYPE_PHPNAME       => array('Id' => 0, 'File' => 1, 'PersonId' => 2, 'Visible' => 3, 'Position' => 4, 'CreatedAt' => 5, 'UpdatedAt' => 6, 'Version' => 7, 'VersionCreatedAt' => 8, 'VersionCreatedBy' => 9, ),
-        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'file' => 1, 'personId' => 2, 'visible' => 3, 'position' => 4, 'createdAt' => 5, 'updatedAt' => 6, 'version' => 7, 'versionCreatedAt' => 8, 'versionCreatedBy' => 9, ),
-        self::TYPE_COLNAME       => array(PersonImageTableMap::ID => 0, PersonImageTableMap::FILE => 1, PersonImageTableMap::PERSON_ID => 2, PersonImageTableMap::VISIBLE => 3, PersonImageTableMap::POSITION => 4, PersonImageTableMap::CREATED_AT => 5, PersonImageTableMap::UPDATED_AT => 6, PersonImageTableMap::VERSION => 7, PersonImageTableMap::VERSION_CREATED_AT => 8, PersonImageTableMap::VERSION_CREATED_BY => 9, ),
-        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'FILE' => 1, 'PERSON_ID' => 2, 'VISIBLE' => 3, 'POSITION' => 4, 'CREATED_AT' => 5, 'UPDATED_AT' => 6, 'VERSION' => 7, 'VERSION_CREATED_AT' => 8, 'VERSION_CREATED_BY' => 9, ),
-        self::TYPE_FIELDNAME     => array('id' => 0, 'file' => 1, 'person_id' => 2, 'visible' => 3, 'position' => 4, 'created_at' => 5, 'updated_at' => 6, 'version' => 7, 'version_created_at' => 8, 'version_created_by' => 9, ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, )
+        self::TYPE_PHPNAME       => array('Id' => 0, 'File' => 1, 'PersonId' => 2, 'Visible' => 3, 'Position' => 4, 'CreatedAt' => 5, 'UpdatedAt' => 6, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'file' => 1, 'personId' => 2, 'visible' => 3, 'position' => 4, 'createdAt' => 5, 'updatedAt' => 6, ),
+        self::TYPE_COLNAME       => array(PersonImageTableMap::ID => 0, PersonImageTableMap::FILE => 1, PersonImageTableMap::PERSON_ID => 2, PersonImageTableMap::VISIBLE => 3, PersonImageTableMap::POSITION => 4, PersonImageTableMap::CREATED_AT => 5, PersonImageTableMap::UPDATED_AT => 6, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'FILE' => 1, 'PERSON_ID' => 2, 'VISIBLE' => 3, 'POSITION' => 4, 'CREATED_AT' => 5, 'UPDATED_AT' => 6, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'file' => 1, 'person_id' => 2, 'visible' => 3, 'position' => 4, 'created_at' => 5, 'updated_at' => 6, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, )
     );
 
     /**
@@ -187,9 +172,6 @@ class PersonImageTableMap extends TableMap
         $this->addColumn('POSITION', 'Position', 'INTEGER', false, null, null);
         $this->addColumn('CREATED_AT', 'CreatedAt', 'TIMESTAMP', false, null, null);
         $this->addColumn('UPDATED_AT', 'UpdatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION', 'Version', 'INTEGER', false, null, 0);
-        $this->addColumn('VERSION_CREATED_AT', 'VersionCreatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION_CREATED_BY', 'VersionCreatedBy', 'VARCHAR', false, 100, null);
     } // initialize()
 
     /**
@@ -199,7 +181,6 @@ class PersonImageTableMap extends TableMap
     {
         $this->addRelation('Person', '\\Team\\Model\\Person', RelationMap::MANY_TO_ONE, array('person_id' => 'id', ), 'CASCADE', null);
         $this->addRelation('PersonImageI18n', '\\Team\\Model\\PersonImageI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'PersonImageI18ns');
-        $this->addRelation('PersonImageVersion', '\\Team\\Model\\PersonImageVersion', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'PersonImageVersions');
     } // buildRelations()
 
     /**
@@ -213,7 +194,6 @@ class PersonImageTableMap extends TableMap
         return array(
             'timestampable' => array('create_column' => 'created_at', 'update_column' => 'updated_at', ),
             'i18n' => array('i18n_table' => '%TABLE%_i18n', 'i18n_phpname' => '%PHPNAME%I18n', 'i18n_columns' => 'title, description, chapo, postscriptum', 'locale_column' => 'locale', 'locale_length' => '5', 'default_locale' => '', 'locale_alias' => '', ),
-            'versionable' => array('version_column' => 'version', 'version_table' => '', 'log_created_at' => 'true', 'log_created_by' => 'true', 'log_comment' => 'false', 'version_created_at_column' => 'version_created_at', 'version_created_by_column' => 'version_created_by', 'version_comment_column' => 'version_comment', ),
         );
     } // getBehaviors()
     /**
@@ -224,7 +204,6 @@ class PersonImageTableMap extends TableMap
         // Invalidate objects in ".$this->getClassNameFromBuilder($joinedTableTableMapBuilder)." instance pool,
         // since one or more of them may be deleted by ON DELETE CASCADE/SETNULL rule.
                 PersonImageI18nTableMap::clearInstancePool();
-                PersonImageVersionTableMap::clearInstancePool();
             }
 
     /**
@@ -372,9 +351,6 @@ class PersonImageTableMap extends TableMap
             $criteria->addSelectColumn(PersonImageTableMap::POSITION);
             $criteria->addSelectColumn(PersonImageTableMap::CREATED_AT);
             $criteria->addSelectColumn(PersonImageTableMap::UPDATED_AT);
-            $criteria->addSelectColumn(PersonImageTableMap::VERSION);
-            $criteria->addSelectColumn(PersonImageTableMap::VERSION_CREATED_AT);
-            $criteria->addSelectColumn(PersonImageTableMap::VERSION_CREATED_BY);
         } else {
             $criteria->addSelectColumn($alias . '.ID');
             $criteria->addSelectColumn($alias . '.FILE');
@@ -383,9 +359,6 @@ class PersonImageTableMap extends TableMap
             $criteria->addSelectColumn($alias . '.POSITION');
             $criteria->addSelectColumn($alias . '.CREATED_AT');
             $criteria->addSelectColumn($alias . '.UPDATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_BY');
         }
     }
 

--- a/Model/Map/PersonTableMap.php
+++ b/Model/Map/PersonTableMap.php
@@ -58,7 +58,7 @@ class PersonTableMap extends TableMap
     /**
      * The total number of columns
      */
-    const NUM_COLUMNS = 8;
+    const NUM_COLUMNS = 5;
 
     /**
      * The number of lazy-loaded columns
@@ -68,7 +68,7 @@ class PersonTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    const NUM_HYDRATE_COLUMNS = 8;
+    const NUM_HYDRATE_COLUMNS = 5;
 
     /**
      * the column name for the ID field
@@ -96,21 +96,6 @@ class PersonTableMap extends TableMap
     const UPDATED_AT = 'person.UPDATED_AT';
 
     /**
-     * the column name for the VERSION field
-     */
-    const VERSION = 'person.VERSION';
-
-    /**
-     * the column name for the VERSION_CREATED_AT field
-     */
-    const VERSION_CREATED_AT = 'person.VERSION_CREATED_AT';
-
-    /**
-     * the column name for the VERSION_CREATED_BY field
-     */
-    const VERSION_CREATED_BY = 'person.VERSION_CREATED_BY';
-
-    /**
      * The default string format for model objects of the related table
      */
     const DEFAULT_STRING_FORMAT = 'YAML';
@@ -131,12 +116,12 @@ class PersonTableMap extends TableMap
      * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
      */
     protected static $fieldNames = array (
-        self::TYPE_PHPNAME       => array('Id', 'FirstName', 'LastName', 'CreatedAt', 'UpdatedAt', 'Version', 'VersionCreatedAt', 'VersionCreatedBy', ),
-        self::TYPE_STUDLYPHPNAME => array('id', 'firstName', 'lastName', 'createdAt', 'updatedAt', 'version', 'versionCreatedAt', 'versionCreatedBy', ),
-        self::TYPE_COLNAME       => array(PersonTableMap::ID, PersonTableMap::FIRST_NAME, PersonTableMap::LAST_NAME, PersonTableMap::CREATED_AT, PersonTableMap::UPDATED_AT, PersonTableMap::VERSION, PersonTableMap::VERSION_CREATED_AT, PersonTableMap::VERSION_CREATED_BY, ),
-        self::TYPE_RAW_COLNAME   => array('ID', 'FIRST_NAME', 'LAST_NAME', 'CREATED_AT', 'UPDATED_AT', 'VERSION', 'VERSION_CREATED_AT', 'VERSION_CREATED_BY', ),
-        self::TYPE_FIELDNAME     => array('id', 'first_name', 'last_name', 'created_at', 'updated_at', 'version', 'version_created_at', 'version_created_by', ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, )
+        self::TYPE_PHPNAME       => array('Id', 'FirstName', 'LastName', 'CreatedAt', 'UpdatedAt', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'firstName', 'lastName', 'createdAt', 'updatedAt', ),
+        self::TYPE_COLNAME       => array(PersonTableMap::ID, PersonTableMap::FIRST_NAME, PersonTableMap::LAST_NAME, PersonTableMap::CREATED_AT, PersonTableMap::UPDATED_AT, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'FIRST_NAME', 'LAST_NAME', 'CREATED_AT', 'UPDATED_AT', ),
+        self::TYPE_FIELDNAME     => array('id', 'first_name', 'last_name', 'created_at', 'updated_at', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, )
     );
 
     /**
@@ -146,12 +131,12 @@ class PersonTableMap extends TableMap
      * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
      */
     protected static $fieldKeys = array (
-        self::TYPE_PHPNAME       => array('Id' => 0, 'FirstName' => 1, 'LastName' => 2, 'CreatedAt' => 3, 'UpdatedAt' => 4, 'Version' => 5, 'VersionCreatedAt' => 6, 'VersionCreatedBy' => 7, ),
-        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'firstName' => 1, 'lastName' => 2, 'createdAt' => 3, 'updatedAt' => 4, 'version' => 5, 'versionCreatedAt' => 6, 'versionCreatedBy' => 7, ),
-        self::TYPE_COLNAME       => array(PersonTableMap::ID => 0, PersonTableMap::FIRST_NAME => 1, PersonTableMap::LAST_NAME => 2, PersonTableMap::CREATED_AT => 3, PersonTableMap::UPDATED_AT => 4, PersonTableMap::VERSION => 5, PersonTableMap::VERSION_CREATED_AT => 6, PersonTableMap::VERSION_CREATED_BY => 7, ),
-        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'FIRST_NAME' => 1, 'LAST_NAME' => 2, 'CREATED_AT' => 3, 'UPDATED_AT' => 4, 'VERSION' => 5, 'VERSION_CREATED_AT' => 6, 'VERSION_CREATED_BY' => 7, ),
-        self::TYPE_FIELDNAME     => array('id' => 0, 'first_name' => 1, 'last_name' => 2, 'created_at' => 3, 'updated_at' => 4, 'version' => 5, 'version_created_at' => 6, 'version_created_by' => 7, ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, )
+        self::TYPE_PHPNAME       => array('Id' => 0, 'FirstName' => 1, 'LastName' => 2, 'CreatedAt' => 3, 'UpdatedAt' => 4, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'firstName' => 1, 'lastName' => 2, 'createdAt' => 3, 'updatedAt' => 4, ),
+        self::TYPE_COLNAME       => array(PersonTableMap::ID => 0, PersonTableMap::FIRST_NAME => 1, PersonTableMap::LAST_NAME => 2, PersonTableMap::CREATED_AT => 3, PersonTableMap::UPDATED_AT => 4, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'FIRST_NAME' => 1, 'LAST_NAME' => 2, 'CREATED_AT' => 3, 'UPDATED_AT' => 4, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'first_name' => 1, 'last_name' => 2, 'created_at' => 3, 'updated_at' => 4, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, )
     );
 
     /**
@@ -175,9 +160,6 @@ class PersonTableMap extends TableMap
         $this->addColumn('LAST_NAME', 'LastName', 'VARCHAR', false, 255, null);
         $this->addColumn('CREATED_AT', 'CreatedAt', 'TIMESTAMP', false, null, null);
         $this->addColumn('UPDATED_AT', 'UpdatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION', 'Version', 'INTEGER', false, null, 0);
-        $this->addColumn('VERSION_CREATED_AT', 'VersionCreatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION_CREATED_BY', 'VersionCreatedBy', 'VARCHAR', false, 100, null);
     } // initialize()
 
     /**
@@ -189,7 +171,6 @@ class PersonTableMap extends TableMap
         $this->addRelation('PersonImage', '\\Team\\Model\\PersonImage', RelationMap::ONE_TO_MANY, array('id' => 'person_id', ), 'CASCADE', null, 'PersonImages');
         $this->addRelation('PersonFunctionLink', '\\Team\\Model\\PersonFunctionLink', RelationMap::ONE_TO_MANY, array('id' => 'person_id', ), 'CASCADE', null, 'PersonFunctionLinks');
         $this->addRelation('PersonI18n', '\\Team\\Model\\PersonI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'PersonI18ns');
-        $this->addRelation('PersonVersion', '\\Team\\Model\\PersonVersion', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'PersonVersions');
     } // buildRelations()
 
     /**
@@ -203,7 +184,6 @@ class PersonTableMap extends TableMap
         return array(
             'timestampable' => array('create_column' => 'created_at', 'update_column' => 'updated_at', ),
             'i18n' => array('i18n_table' => '%TABLE%_i18n', 'i18n_phpname' => '%PHPNAME%I18n', 'i18n_columns' => 'description', 'locale_column' => 'locale', 'locale_length' => '5', 'default_locale' => '', 'locale_alias' => '', ),
-            'versionable' => array('version_column' => 'version', 'version_table' => '', 'log_created_at' => 'true', 'log_created_by' => 'true', 'log_comment' => 'false', 'version_created_at_column' => 'version_created_at', 'version_created_by_column' => 'version_created_by', 'version_comment_column' => 'version_comment', ),
         );
     } // getBehaviors()
     /**
@@ -217,7 +197,6 @@ class PersonTableMap extends TableMap
                 PersonImageTableMap::clearInstancePool();
                 PersonFunctionLinkTableMap::clearInstancePool();
                 PersonI18nTableMap::clearInstancePool();
-                PersonVersionTableMap::clearInstancePool();
             }
 
     /**
@@ -363,18 +342,12 @@ class PersonTableMap extends TableMap
             $criteria->addSelectColumn(PersonTableMap::LAST_NAME);
             $criteria->addSelectColumn(PersonTableMap::CREATED_AT);
             $criteria->addSelectColumn(PersonTableMap::UPDATED_AT);
-            $criteria->addSelectColumn(PersonTableMap::VERSION);
-            $criteria->addSelectColumn(PersonTableMap::VERSION_CREATED_AT);
-            $criteria->addSelectColumn(PersonTableMap::VERSION_CREATED_BY);
         } else {
             $criteria->addSelectColumn($alias . '.ID');
             $criteria->addSelectColumn($alias . '.FIRST_NAME');
             $criteria->addSelectColumn($alias . '.LAST_NAME');
             $criteria->addSelectColumn($alias . '.CREATED_AT');
             $criteria->addSelectColumn($alias . '.UPDATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_BY');
         }
     }
 

--- a/Model/Map/PersonTeamLinkTableMap.php
+++ b/Model/Map/PersonTeamLinkTableMap.php
@@ -58,7 +58,7 @@ class PersonTeamLinkTableMap extends TableMap
     /**
      * The total number of columns
      */
-    const NUM_COLUMNS = 8;
+    const NUM_COLUMNS = 5;
 
     /**
      * The number of lazy-loaded columns
@@ -68,7 +68,7 @@ class PersonTeamLinkTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    const NUM_HYDRATE_COLUMNS = 8;
+    const NUM_HYDRATE_COLUMNS = 5;
 
     /**
      * the column name for the ID field
@@ -96,21 +96,6 @@ class PersonTeamLinkTableMap extends TableMap
     const UPDATED_AT = 'person_team_link.UPDATED_AT';
 
     /**
-     * the column name for the VERSION field
-     */
-    const VERSION = 'person_team_link.VERSION';
-
-    /**
-     * the column name for the VERSION_CREATED_AT field
-     */
-    const VERSION_CREATED_AT = 'person_team_link.VERSION_CREATED_AT';
-
-    /**
-     * the column name for the VERSION_CREATED_BY field
-     */
-    const VERSION_CREATED_BY = 'person_team_link.VERSION_CREATED_BY';
-
-    /**
      * The default string format for model objects of the related table
      */
     const DEFAULT_STRING_FORMAT = 'YAML';
@@ -122,12 +107,12 @@ class PersonTeamLinkTableMap extends TableMap
      * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
      */
     protected static $fieldNames = array (
-        self::TYPE_PHPNAME       => array('Id', 'PersonId', 'TeamId', 'CreatedAt', 'UpdatedAt', 'Version', 'VersionCreatedAt', 'VersionCreatedBy', ),
-        self::TYPE_STUDLYPHPNAME => array('id', 'personId', 'teamId', 'createdAt', 'updatedAt', 'version', 'versionCreatedAt', 'versionCreatedBy', ),
-        self::TYPE_COLNAME       => array(PersonTeamLinkTableMap::ID, PersonTeamLinkTableMap::PERSON_ID, PersonTeamLinkTableMap::TEAM_ID, PersonTeamLinkTableMap::CREATED_AT, PersonTeamLinkTableMap::UPDATED_AT, PersonTeamLinkTableMap::VERSION, PersonTeamLinkTableMap::VERSION_CREATED_AT, PersonTeamLinkTableMap::VERSION_CREATED_BY, ),
-        self::TYPE_RAW_COLNAME   => array('ID', 'PERSON_ID', 'TEAM_ID', 'CREATED_AT', 'UPDATED_AT', 'VERSION', 'VERSION_CREATED_AT', 'VERSION_CREATED_BY', ),
-        self::TYPE_FIELDNAME     => array('id', 'person_id', 'team_id', 'created_at', 'updated_at', 'version', 'version_created_at', 'version_created_by', ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, )
+        self::TYPE_PHPNAME       => array('Id', 'PersonId', 'TeamId', 'CreatedAt', 'UpdatedAt', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'personId', 'teamId', 'createdAt', 'updatedAt', ),
+        self::TYPE_COLNAME       => array(PersonTeamLinkTableMap::ID, PersonTeamLinkTableMap::PERSON_ID, PersonTeamLinkTableMap::TEAM_ID, PersonTeamLinkTableMap::CREATED_AT, PersonTeamLinkTableMap::UPDATED_AT, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'PERSON_ID', 'TEAM_ID', 'CREATED_AT', 'UPDATED_AT', ),
+        self::TYPE_FIELDNAME     => array('id', 'person_id', 'team_id', 'created_at', 'updated_at', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, )
     );
 
     /**
@@ -137,12 +122,12 @@ class PersonTeamLinkTableMap extends TableMap
      * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
      */
     protected static $fieldKeys = array (
-        self::TYPE_PHPNAME       => array('Id' => 0, 'PersonId' => 1, 'TeamId' => 2, 'CreatedAt' => 3, 'UpdatedAt' => 4, 'Version' => 5, 'VersionCreatedAt' => 6, 'VersionCreatedBy' => 7, ),
-        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'personId' => 1, 'teamId' => 2, 'createdAt' => 3, 'updatedAt' => 4, 'version' => 5, 'versionCreatedAt' => 6, 'versionCreatedBy' => 7, ),
-        self::TYPE_COLNAME       => array(PersonTeamLinkTableMap::ID => 0, PersonTeamLinkTableMap::PERSON_ID => 1, PersonTeamLinkTableMap::TEAM_ID => 2, PersonTeamLinkTableMap::CREATED_AT => 3, PersonTeamLinkTableMap::UPDATED_AT => 4, PersonTeamLinkTableMap::VERSION => 5, PersonTeamLinkTableMap::VERSION_CREATED_AT => 6, PersonTeamLinkTableMap::VERSION_CREATED_BY => 7, ),
-        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'PERSON_ID' => 1, 'TEAM_ID' => 2, 'CREATED_AT' => 3, 'UPDATED_AT' => 4, 'VERSION' => 5, 'VERSION_CREATED_AT' => 6, 'VERSION_CREATED_BY' => 7, ),
-        self::TYPE_FIELDNAME     => array('id' => 0, 'person_id' => 1, 'team_id' => 2, 'created_at' => 3, 'updated_at' => 4, 'version' => 5, 'version_created_at' => 6, 'version_created_by' => 7, ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, )
+        self::TYPE_PHPNAME       => array('Id' => 0, 'PersonId' => 1, 'TeamId' => 2, 'CreatedAt' => 3, 'UpdatedAt' => 4, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'personId' => 1, 'teamId' => 2, 'createdAt' => 3, 'updatedAt' => 4, ),
+        self::TYPE_COLNAME       => array(PersonTeamLinkTableMap::ID => 0, PersonTeamLinkTableMap::PERSON_ID => 1, PersonTeamLinkTableMap::TEAM_ID => 2, PersonTeamLinkTableMap::CREATED_AT => 3, PersonTeamLinkTableMap::UPDATED_AT => 4, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'PERSON_ID' => 1, 'TEAM_ID' => 2, 'CREATED_AT' => 3, 'UPDATED_AT' => 4, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'person_id' => 1, 'team_id' => 2, 'created_at' => 3, 'updated_at' => 4, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, )
     );
 
     /**
@@ -166,9 +151,6 @@ class PersonTeamLinkTableMap extends TableMap
         $this->addForeignKey('TEAM_ID', 'TeamId', 'INTEGER', 'team', 'ID', true, null, null);
         $this->addColumn('CREATED_AT', 'CreatedAt', 'TIMESTAMP', false, null, null);
         $this->addColumn('UPDATED_AT', 'UpdatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION', 'Version', 'INTEGER', false, null, 0);
-        $this->addColumn('VERSION_CREATED_AT', 'VersionCreatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION_CREATED_BY', 'VersionCreatedBy', 'VARCHAR', false, 100, null);
     } // initialize()
 
     /**
@@ -178,7 +160,6 @@ class PersonTeamLinkTableMap extends TableMap
     {
         $this->addRelation('Person', '\\Team\\Model\\Person', RelationMap::MANY_TO_ONE, array('person_id' => 'id', ), 'CASCADE', null);
         $this->addRelation('Team', '\\Team\\Model\\Team', RelationMap::MANY_TO_ONE, array('team_id' => 'id', ), 'CASCADE', null);
-        $this->addRelation('PersonTeamLinkVersion', '\\Team\\Model\\PersonTeamLinkVersion', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'PersonTeamLinkVersions');
     } // buildRelations()
 
     /**
@@ -191,18 +172,8 @@ class PersonTeamLinkTableMap extends TableMap
     {
         return array(
             'timestampable' => array('create_column' => 'created_at', 'update_column' => 'updated_at', ),
-            'versionable' => array('version_column' => 'version', 'version_table' => '', 'log_created_at' => 'true', 'log_created_by' => 'true', 'log_comment' => 'false', 'version_created_at_column' => 'version_created_at', 'version_created_by_column' => 'version_created_by', 'version_comment_column' => 'version_comment', ),
         );
     } // getBehaviors()
-    /**
-     * Method to invalidate the instance pool of all tables related to person_team_link     * by a foreign key with ON DELETE CASCADE
-     */
-    public static function clearRelatedInstancePool()
-    {
-        // Invalidate objects in ".$this->getClassNameFromBuilder($joinedTableTableMapBuilder)." instance pool,
-        // since one or more of them may be deleted by ON DELETE CASCADE/SETNULL rule.
-                PersonTeamLinkVersionTableMap::clearInstancePool();
-            }
 
     /**
      * Retrieves a string version of the primary key from the DB resultset row that can be used to uniquely identify a row in this table.
@@ -347,18 +318,12 @@ class PersonTeamLinkTableMap extends TableMap
             $criteria->addSelectColumn(PersonTeamLinkTableMap::TEAM_ID);
             $criteria->addSelectColumn(PersonTeamLinkTableMap::CREATED_AT);
             $criteria->addSelectColumn(PersonTeamLinkTableMap::UPDATED_AT);
-            $criteria->addSelectColumn(PersonTeamLinkTableMap::VERSION);
-            $criteria->addSelectColumn(PersonTeamLinkTableMap::VERSION_CREATED_AT);
-            $criteria->addSelectColumn(PersonTeamLinkTableMap::VERSION_CREATED_BY);
         } else {
             $criteria->addSelectColumn($alias . '.ID');
             $criteria->addSelectColumn($alias . '.PERSON_ID');
             $criteria->addSelectColumn($alias . '.TEAM_ID');
             $criteria->addSelectColumn($alias . '.CREATED_AT');
             $criteria->addSelectColumn($alias . '.UPDATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_BY');
         }
     }
 

--- a/Model/Map/TeamTableMap.php
+++ b/Model/Map/TeamTableMap.php
@@ -58,7 +58,7 @@ class TeamTableMap extends TableMap
     /**
      * The total number of columns
      */
-    const NUM_COLUMNS = 6;
+    const NUM_COLUMNS = 3;
 
     /**
      * The number of lazy-loaded columns
@@ -68,7 +68,7 @@ class TeamTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    const NUM_HYDRATE_COLUMNS = 6;
+    const NUM_HYDRATE_COLUMNS = 3;
 
     /**
      * the column name for the ID field
@@ -84,21 +84,6 @@ class TeamTableMap extends TableMap
      * the column name for the UPDATED_AT field
      */
     const UPDATED_AT = 'team.UPDATED_AT';
-
-    /**
-     * the column name for the VERSION field
-     */
-    const VERSION = 'team.VERSION';
-
-    /**
-     * the column name for the VERSION_CREATED_AT field
-     */
-    const VERSION_CREATED_AT = 'team.VERSION_CREATED_AT';
-
-    /**
-     * the column name for the VERSION_CREATED_BY field
-     */
-    const VERSION_CREATED_BY = 'team.VERSION_CREATED_BY';
 
     /**
      * The default string format for model objects of the related table
@@ -121,12 +106,12 @@ class TeamTableMap extends TableMap
      * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
      */
     protected static $fieldNames = array (
-        self::TYPE_PHPNAME       => array('Id', 'CreatedAt', 'UpdatedAt', 'Version', 'VersionCreatedAt', 'VersionCreatedBy', ),
-        self::TYPE_STUDLYPHPNAME => array('id', 'createdAt', 'updatedAt', 'version', 'versionCreatedAt', 'versionCreatedBy', ),
-        self::TYPE_COLNAME       => array(TeamTableMap::ID, TeamTableMap::CREATED_AT, TeamTableMap::UPDATED_AT, TeamTableMap::VERSION, TeamTableMap::VERSION_CREATED_AT, TeamTableMap::VERSION_CREATED_BY, ),
-        self::TYPE_RAW_COLNAME   => array('ID', 'CREATED_AT', 'UPDATED_AT', 'VERSION', 'VERSION_CREATED_AT', 'VERSION_CREATED_BY', ),
-        self::TYPE_FIELDNAME     => array('id', 'created_at', 'updated_at', 'version', 'version_created_at', 'version_created_by', ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, )
+        self::TYPE_PHPNAME       => array('Id', 'CreatedAt', 'UpdatedAt', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'createdAt', 'updatedAt', ),
+        self::TYPE_COLNAME       => array(TeamTableMap::ID, TeamTableMap::CREATED_AT, TeamTableMap::UPDATED_AT, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'CREATED_AT', 'UPDATED_AT', ),
+        self::TYPE_FIELDNAME     => array('id', 'created_at', 'updated_at', ),
+        self::TYPE_NUM           => array(0, 1, 2, )
     );
 
     /**
@@ -136,12 +121,12 @@ class TeamTableMap extends TableMap
      * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
      */
     protected static $fieldKeys = array (
-        self::TYPE_PHPNAME       => array('Id' => 0, 'CreatedAt' => 1, 'UpdatedAt' => 2, 'Version' => 3, 'VersionCreatedAt' => 4, 'VersionCreatedBy' => 5, ),
-        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'createdAt' => 1, 'updatedAt' => 2, 'version' => 3, 'versionCreatedAt' => 4, 'versionCreatedBy' => 5, ),
-        self::TYPE_COLNAME       => array(TeamTableMap::ID => 0, TeamTableMap::CREATED_AT => 1, TeamTableMap::UPDATED_AT => 2, TeamTableMap::VERSION => 3, TeamTableMap::VERSION_CREATED_AT => 4, TeamTableMap::VERSION_CREATED_BY => 5, ),
-        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'CREATED_AT' => 1, 'UPDATED_AT' => 2, 'VERSION' => 3, 'VERSION_CREATED_AT' => 4, 'VERSION_CREATED_BY' => 5, ),
-        self::TYPE_FIELDNAME     => array('id' => 0, 'created_at' => 1, 'updated_at' => 2, 'version' => 3, 'version_created_at' => 4, 'version_created_by' => 5, ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, )
+        self::TYPE_PHPNAME       => array('Id' => 0, 'CreatedAt' => 1, 'UpdatedAt' => 2, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'createdAt' => 1, 'updatedAt' => 2, ),
+        self::TYPE_COLNAME       => array(TeamTableMap::ID => 0, TeamTableMap::CREATED_AT => 1, TeamTableMap::UPDATED_AT => 2, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'CREATED_AT' => 1, 'UPDATED_AT' => 2, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'created_at' => 1, 'updated_at' => 2, ),
+        self::TYPE_NUM           => array(0, 1, 2, )
     );
 
     /**
@@ -163,9 +148,6 @@ class TeamTableMap extends TableMap
         $this->addPrimaryKey('ID', 'Id', 'INTEGER', true, null, null);
         $this->addColumn('CREATED_AT', 'CreatedAt', 'TIMESTAMP', false, null, null);
         $this->addColumn('UPDATED_AT', 'UpdatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION', 'Version', 'INTEGER', false, null, 0);
-        $this->addColumn('VERSION_CREATED_AT', 'VersionCreatedAt', 'TIMESTAMP', false, null, null);
-        $this->addColumn('VERSION_CREATED_BY', 'VersionCreatedBy', 'VARCHAR', false, 100, null);
     } // initialize()
 
     /**
@@ -175,7 +157,6 @@ class TeamTableMap extends TableMap
     {
         $this->addRelation('PersonTeamLink', '\\Team\\Model\\PersonTeamLink', RelationMap::ONE_TO_MANY, array('id' => 'team_id', ), 'CASCADE', null, 'PersonTeamLinks');
         $this->addRelation('TeamI18n', '\\Team\\Model\\TeamI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'TeamI18ns');
-        $this->addRelation('TeamVersion', '\\Team\\Model\\TeamVersion', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'TeamVersions');
     } // buildRelations()
 
     /**
@@ -189,7 +170,6 @@ class TeamTableMap extends TableMap
         return array(
             'timestampable' => array('create_column' => 'created_at', 'update_column' => 'updated_at', ),
             'i18n' => array('i18n_table' => '%TABLE%_i18n', 'i18n_phpname' => '%PHPNAME%I18n', 'i18n_columns' => 'title,description', 'locale_column' => 'locale', 'locale_length' => '5', 'default_locale' => '', 'locale_alias' => '', ),
-            'versionable' => array('version_column' => 'version', 'version_table' => '', 'log_created_at' => 'true', 'log_created_by' => 'true', 'log_comment' => 'false', 'version_created_at_column' => 'version_created_at', 'version_created_by_column' => 'version_created_by', 'version_comment_column' => 'version_comment', ),
         );
     } // getBehaviors()
     /**
@@ -201,7 +181,6 @@ class TeamTableMap extends TableMap
         // since one or more of them may be deleted by ON DELETE CASCADE/SETNULL rule.
                 PersonTeamLinkTableMap::clearInstancePool();
                 TeamI18nTableMap::clearInstancePool();
-                TeamVersionTableMap::clearInstancePool();
             }
 
     /**
@@ -345,16 +324,10 @@ class TeamTableMap extends TableMap
             $criteria->addSelectColumn(TeamTableMap::ID);
             $criteria->addSelectColumn(TeamTableMap::CREATED_AT);
             $criteria->addSelectColumn(TeamTableMap::UPDATED_AT);
-            $criteria->addSelectColumn(TeamTableMap::VERSION);
-            $criteria->addSelectColumn(TeamTableMap::VERSION_CREATED_AT);
-            $criteria->addSelectColumn(TeamTableMap::VERSION_CREATED_BY);
         } else {
             $criteria->addSelectColumn($alias . '.ID');
             $criteria->addSelectColumn($alias . '.CREATED_AT');
             $criteria->addSelectColumn($alias . '.UPDATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_AT');
-            $criteria->addSelectColumn($alias . '.VERSION_CREATED_BY');
         }
     }
 

--- a/Service/PersonService.php
+++ b/Service/PersonService.php
@@ -51,37 +51,8 @@ class PersonService extends AbstractBaseService implements BaseServiceInterface
 
     protected function updateProcess(Event $event)
     {
-        /**
-         * @var PersonEvent $event
-         * @var Person $person
-         */
-        $person = $event->getPerson();
-
-        $existingPersonQuery = PersonQuery::create()
-            ->filterById($person->getId())
-            ->filterByLastName($person->getLastName())
-            ->filterByFirstName($person->getFirstName())
-        ;
-
-        if (null === $existingPersonQuery->findOne()) {
-            $person->save();
-        // to avoid infinite loops due to model, we need to register by hand the new person description if it has been changed
-        } elseif (
-            null === $existingPersonQuery
-                ->usePersonI18nQuery()
-                    ->filterByLocale($person->getLocale())
-                    ->filterByDescription($person->getDescription())
-                ->endUse()
-                ->findOne()
-        ) {
-            PersonI18nQuery::create()
-                ->filterByLocale($person->getLocale())
-                ->filterById($person->getId())
-                ->findOne()
-                ->setDescription($person->getDescription())
-                ->save()
-            ;
-        }
+        /** @var PersonEvent $event */
+        $event->getPerson()->save();
     }
 
     protected function deleteProcess(Event $event)

--- a/Setup/update/sql/1.1.0.sql
+++ b/Setup/update/sql/1.1.0.sql
@@ -1,0 +1,13 @@
+ALTER TABLE `team` DROP COLUMN `version`, DROP COLUMN `version_created_at`, DROP COLUMN `version_created_by`;
+ALTER TABLE `person_team_link` DROP COLUMN `version`, DROP COLUMN `version_created_at`, DROP COLUMN `version_created_by`;
+ALTER TABLE `person` DROP COLUMN `version`, DROP COLUMN `version_created_at`, DROP COLUMN `version_created_by`;
+ALTER TABLE `person_image` DROP COLUMN `version`, DROP COLUMN `version_created_at`, DROP COLUMN `version_created_by`;
+ALTER TABLE `person_function_link` DROP COLUMN `version`, DROP COLUMN `version_created_at`, DROP COLUMN `version_created_by`;
+ALTER TABLE `person_function` DROP COLUMN `version`, DROP COLUMN `version_created_at`, DROP COLUMN `version_created_by`;
+
+DROP TABLE `team_version`;
+DROP TABLE `person_team_link_version`;
+DROP TABLE `person_version`;
+DROP TABLE `person_image_version`;
+DROP TABLE `person_function_link_version`;
+DROP TABLE `person_function_version`;


### PR DESCRIPTION
The versioning causes infinite loop when saving models due to a propel issue (because of the foreign constraints). In addition, this behavior isn't necessary for this module.
